### PR TITLE
Optimize spike detection

### DIFF
--- a/scripts/run_spikeSorting.m
+++ b/scripts/run_spikeSorting.m
@@ -24,7 +24,7 @@ end
 
 %% spike detection:
 delete(gcp('nocreate'))
-parpool(5);
+parpool(1);
 
 expFilePath = [filePath, '/Experiment', sprintf('-%d', expIds)];
 

--- a/scripts/run_spikeSorting.m
+++ b/scripts/run_spikeSorting.m
@@ -9,7 +9,7 @@ filePath = '/Users/XinNiuAdmin/HoffmanMount/data/PIPELINE_vc/ANALYSIS/MovieParad
 
 % 0: will remove all previous unpack files.
 % 1: skip existing files.
-skipExist = 0;
+skipExist = 1;
 
 microFiles = [];
 timestampFiles = [];

--- a/scripts/run_spikeSorting.m
+++ b/scripts/run_spikeSorting.m
@@ -24,7 +24,7 @@ end
 
 %% spike detection:
 delete(gcp('nocreate'))
-parpool(1);
+parpool(2);
 
 expFilePath = [filePath, '/Experiment', sprintf('-%d', expIds)];
 

--- a/scripts/run_spikeSorting.m
+++ b/scripts/run_spikeSorting.m
@@ -19,6 +19,7 @@ for i = 1:length(expIds)
     microFiles = [microFiles, readcell(fullfile(microFilePath, 'outFileNames.csv'), Delimiter=",")];
     timestampFile = dir(fullfile(microFilePath, 'lfpTimeStamps*.mat'));
     timestampFiles = [timestampFiles, fullfile(microFilePath, {timestampFile.name})];
+    expNames{i} = sprintf('Exp%d', expIds(i));
 end
 
 
@@ -30,7 +31,7 @@ expFilePath = [filePath, '/Experiment', sprintf('-%d', expIds)];
 
 outputPath = fullfile(expFilePath, 'CSC_micro_spikes');
 
-spikeDetection(microFiles, timestampFiles, outputPath, [], skipExist)
+spikeDetection(microFiles, timestampFiles, outputPath, expNames, skipExist)
 disp('Spike Detection Finished!')
 
 %% spike clustering:

--- a/spikeDetection.m
+++ b/spikeDetection.m
@@ -37,9 +37,10 @@ parfor i = 1: size(cscFiles, 1)
     xfDetect = cell(nSegments, 1);
 
     [thr_all, outputStruct, param, maxAmp] = getDetectionThresh(channelFiles);
+    thr = NaN;
 
     for j = 1: nSegments
-        if isempty(channelFiles{j}, "file")
+        if ~exist(channelFiles{j}, "file")
             continue
         end
 

--- a/spikeDetection.m
+++ b/spikeDetection.m
@@ -12,13 +12,8 @@ if nargin < 5
     skipExist = false;
 end
 
-
 makeOutputPath(cscFiles, outputPath, skipExist)
-
 nSegments = length(timestampFiles);
-for j = nSegments:-1:1
-    [timestamps{j}, duration(j)] = readTimestamps(timestampFiles{j});
-end
 
 parfor i = 1: size(cscFiles, 1)
     channelFiles = cscFiles(i,:);
@@ -32,46 +27,27 @@ parfor i = 1: size(cscFiles, 1)
         continue
     end
 
-    param = set_parameters();
-    maxAmp = 500;
-
-    signals = cell(nSegments, 1);
     %outputStruct = cell(nSegments, 1);
     spikes = cell(nSegments, 1);
     spikeCodes = cell(nSegments, 1);
     spikeHist = cell(nSegments, 1);
     spikeHistPrecise = cell(nSegments, 1);
     spikeTimestamps = cell(nSegments, 1);
-    thr = zeros(nSegments, 1);
     xfDetect = cell(nSegments, 1);
-    outputStruct = cell(nSegments, 1);
 
-    for j = nSegments:-1:1
-        [signals{j}, samplingInterval] = readCSC(channelFiles{j});
-
-        param.sr = 1/samplingInterval;
-        param.ref = floor(1.5 * param.sr/1000);
-        [thr(j), outputStruct{j}] = getDetectionThresh(signals{j}, param, maxAmp);
-    end
-
-    outputStruct = cell2mat(outputStruct);
-
-    thr_all = min(thr);
-    % it shouldn't go less than 18. If it does, it probably found a file with a long stretch of flat, and will then find millions of spikes in the non-flat section.
-    thr_all = max(thr_all, 18);
-    maxThr = max([outputStruct.thrmax]);
-    common_noise_std_detect = min([outputStruct.noise_std_detect]);
-    common_noise_std_sorted = min([outputStruct.noise_std_sorted]);
+    [thr_all, outputStruct, param, maxAmp] = getDetectionThresh(channelFiles);
 
     for j = 1: nSegments
-        outputStruct(j).thrmax = maxThr;
-        outputStruct(j).noise_std_detect = common_noise_std_detect;
-        outputStruct(j).noise_std_sorted = common_noise_std_sorted;
-        outputStruct(j).thr = thr_all;
+        if isempty(channelFiles{j}, "file")
+            continue
+        end
 
-        [spikes{j}, thr, index, outputStruct(j), xfDetect{j}] = amp_detect_AS(signals{j}, param, maxAmp, timestamps{j}, thr_all, outputStruct(j));
-        spikeTimestamps{j} = timestamps{j}(index);
-        [spikeCodes{j}, spikeHist{j}, spikeHistPrecise{j}] = getSpikeCodes(spikes{j}, spikeTimestamps{j}, duration(j), param, outputStruct(j));
+        signal = readCSC(channelFiles{j});
+        [timestamps, duration] = readTimestamps(timestampFiles{j});
+
+        [spikes{j}, thr, index, outputStruct(j), xfDetect{j}] = amp_detect_AS(signal, param, maxAmp, timestamps, thr_all, outputStruct(j));
+        spikeTimestamps{j} = timestamps(index);
+        [spikeCodes{j}, spikeHist{j}, spikeHistPrecise{j}] = getSpikeCodes(spikes{j}, spikeTimestamps{j}, duration, param, outputStruct(j));
         if ~isempty(spikeCodes{j})
             spikeCodes{j}.ExpName = repmat(experimentName(j), height(spikeCodes{j}), 1);
         end

--- a/spikeDetection.m
+++ b/spikeDetection.m
@@ -12,6 +12,8 @@ if nargin < 5
     skipExist = false;
 end
 
+saveXfDetect = false;
+
 makeOutputPath(cscFiles, outputPath, skipExist)
 nSegments = length(timestampFiles);
 
@@ -27,7 +29,6 @@ parfor i = 1: size(cscFiles, 1)
         continue
     end
 
-    %outputStruct = cell(nSegments, 1);
     spikes = cell(nSegments, 1);
     spikeCodes = cell(nSegments, 1);
     spikeHist = cell(nSegments, 1);
@@ -45,7 +46,12 @@ parfor i = 1: size(cscFiles, 1)
         signal = readCSC(channelFiles{j});
         [timestamps, duration] = readTimestamps(timestampFiles{j});
 
-        [spikes{j}, thr, index, outputStruct(j), xfDetect{j}] = amp_detect_AS(signal, param, maxAmp, timestamps, thr_all, outputStruct(j));
+        if saveXfDetect
+            [spikes{j}, thr, index, outputStruct(j), xfDetect{j}] = amp_detect_AS(signal, param, maxAmp, timestamps, thr_all, outputStruct(j));
+        else
+            [spikes{j}, thr, index, outputStruct(j), ~] = amp_detect_AS(signal, param, maxAmp, timestamps, thr_all, outputStruct(j));
+        end
+
         spikeTimestamps{j} = timestamps(index);
         [spikeCodes{j}, spikeHist{j}, spikeHistPrecise{j}] = getSpikeCodes(spikes{j}, spikeTimestamps{j}, duration, param, outputStruct(j));
         if ~isempty(spikeCodes{j})
@@ -68,7 +74,10 @@ parfor i = 1: size(cscFiles, 1)
     matobj.spikeCodes = vertcat(spikeCodes{:});
     matobj.spikeHist = [spikeHist{:}];
     matobj.spikeHistPrecise = [spikeHistPrecise{:}];
-    matobj.xfDetect = [xfDetect{:}];
+
+    if saveXfDetect
+        matobj.xfDetect = [xfDetect{:}];
+    end
 
 end
 end

--- a/spikeDetection.m
+++ b/spikeDetection.m
@@ -9,7 +9,7 @@ if nargin < 4 || isempty(experimentName)
 end
 
 if nargin < 5
-    skipExist = false;
+    skipExist = true;
 end
 
 saveXfDetect = false;

--- a/spikeSort/getDetectionThresh.m
+++ b/spikeSort/getDetectionThresh.m
@@ -1,38 +1,61 @@
-function [thr, outputStruct] = getDetectionThresh(x, param, maxAmp)
+function [thr_all, outputStruct] = getDetectionThresh(channleFiles)
 % Does the first few steps of spike detection to find the threshold. This
 % allows for using the same threshold across multiple sessions. Returns
 % thr, as well as a struct with other variables created so that these steps
 % can be skipped in spikeDetect if the struct is passed in.
 
+    param = set_parameters();
+    maxAmp = 500;
+    thr = zeros(nSegments, 1);
 
-sr = param.sr;
-stdmin = param.stdmin;
-stdmax = param.stdmax;
-fmin_detect = param.detect_fmin;
-fmax_detect = param.detect_fmax;
-fmin_sort = param.sort_fmin;
-fmax_sort = param.sort_fmax;
+    for i = 1:length(channleFiles)
+        [signal, samplingInterval] = readCSC(channelFiles{j});
+        param.sr = 1/samplingInterval;
+        param.ref = floor(1.5 * param.sr/1000);
+
+        sr = param.sr;
+        stdmin = param.stdmin;
+        stdmax = param.stdmax;
+        fmin_detect = param.detect_fmin;
+        fmax_detect = param.detect_fmax;
+        fmin_sort = param.sort_fmin;
+        fmax_sort = param.sort_fmax;
 
 
-%HIGH-PASS FILTER OF THE DATA
-if exist('ellip','file')                  % Checks for the signal processing toolbox
-    [b_detect,a_detect] = ellip(param.detect_order,0.1,40,[fmin_detect fmax_detect]*2/sr);
-    [b,a] = ellip(param.sort_order,0.1,40,[fmin_sort fmax_sort]*2/sr);
-    xf_detect = filtfilt(b_detect, a_detect, x);
-    xf = filtfilt(b, a, x);
-else
-    xf = fix_filter(x);                   % bandpass filtering between [300 3000] without the toolbox.
-    xf_detect = xf;
-end
+        %HIGH-PASS FILTER OF THE DATA
+        if exist('ellip','file')                  % Checks for the signal processing toolbox
+            [b_detect,a_detect] = ellip(param.detect_order,0.1,40,[fmin_detect fmax_detect]*2/sr);
+            [b,a] = ellip(param.sort_order,0.1,40,[fmin_sort fmax_sort]*2/sr);
+            xf_detect = filtfilt(b_detect, a_detect, x);
+            xf = filtfilt(b, a, x);
+        else
+            xf = fix_filter(x);                   % bandpass filtering between [300 3000] without the toolbox.
+            xf_detect = xf;
+        end
 
-noise_std_detect = median(abs(xf_detect))/0.6745;
-noise_std_sorted = median(abs(xf));
-thr = stdmin * noise_std_detect;        %thr for detection is based on detect settings.
-thrmax = min(maxAmp, stdmax * noise_std_sorted);     %thrmax for artifact removal is based on sorted settings.
+        noise_std_detect = median(abs(xf_detect))/0.6745;
+        noise_std_sorted = median(abs(xf));
+        thr(i) = stdmin * noise_std_detect;        %thr for detection is based on detect settings.
+        thrmax = min(maxAmp, stdmax * noise_std_sorted);     %thrmax for artifact removal is based on sorted settings.
 
-outputStruct.xf = xf;
-outputStruct.xf_detect = xf_detect;
-outputStruct.noise_std_detect = noise_std_detect;
-outputStruct.noise_std_sorted = noise_std_sorted;
-outputStruct.thr = thr;
-outputStruct.thrmax = thrmax;
+        outputStruct(i).xf = xf;
+        outputStruct(i).xf_detect = xf_detect;
+        outputStruct(i).noise_std_detect = noise_std_detect;
+        outputStruct(i).noise_std_sorted = noise_std_sorted;
+        outputStruct(i).thr = thr;
+        outputStruct(i).thrmax = thrmax;
+
+    end
+
+    thr_all = min(thr);
+    % it shouldn't go less than 18. If it does, it probably found a file with a long stretch of flat, and will then find millions of spikes in the non-flat section.
+    thr_all = max(thr_all, 18);
+
+    maxThr = max([outputStruct.thrmax]);
+    common_noise_std_detect = min([outputStruct.noise_std_detect]);
+    common_noise_std_sorted = min([outputStruct.noise_std_sorted]);
+
+    outputStruct(:).thrmax = maxThr;
+    outputStruct(:).noise_std_detect = common_noise_std_detect;
+    outputStruct(:).noise_std_sorted = common_noise_std_sorted;
+    outputStruct(:).thr = thr_all;

--- a/spikeSort/getDetectionThresh.m
+++ b/spikeSort/getDetectionThresh.m
@@ -1,4 +1,4 @@
-function [thr_all, outputStruct] = getDetectionThresh(channleFiles)
+function [thr_all, outputStruct, param, maxAmp] = getDetectionThresh(channelFiles)
 % Does the first few steps of spike detection to find the threshold. This
 % allows for using the same threshold across multiple sessions. Returns
 % thr, as well as a struct with other variables created so that these steps
@@ -6,10 +6,10 @@ function [thr_all, outputStruct] = getDetectionThresh(channleFiles)
 
     param = set_parameters();
     maxAmp = 500;
-    thr = zeros(nSegments, 1);
+    thr = zeros(length(channelFiles), 1);
 
-    for i = 1:length(channleFiles)
-        [signal, samplingInterval] = readCSC(channelFiles{j});
+    for i = 1:length(channelFiles)
+        [x, samplingInterval] = readCSC(channelFiles{i});
         param.sr = 1/samplingInterval;
         param.ref = floor(1.5 * param.sr/1000);
 

--- a/spikeSort/getDetectionThresh.m
+++ b/spikeSort/getDetectionThresh.m
@@ -55,7 +55,9 @@ function [thr_all, outputStruct, param, maxAmp] = getDetectionThresh(channelFile
     common_noise_std_detect = min([outputStruct.noise_std_detect]);
     common_noise_std_sorted = min([outputStruct.noise_std_sorted]);
 
-    outputStruct(:).thrmax = maxThr;
-    outputStruct(:).noise_std_detect = common_noise_std_detect;
-    outputStruct(:).noise_std_sorted = common_noise_std_sorted;
-    outputStruct(:).thr = thr_all;
+    for i = 1:length(channelFiles)
+        outputStruct(i).thrmax = maxThr;
+        outputStruct(i).noise_std_detect = common_noise_std_detect;
+        outputStruct(i).noise_std_sorted = common_noise_std_sorted;
+        outputStruct(i).thr = thr_all;
+    end


### PR DESCRIPTION
In multi-exp analysis, we read all signals across experiments (exp 3 to 11 for patient 573). This requires huge memory usage. This PR read one csc file each time, save thresh for spike detection and save the max thresh and other parameters saved in a struct.