### PR TITLE
Discard remove avgspikes

### DIFF
--- a/extractLFP.m
+++ b/extractLFP.m
@@ -13,7 +13,7 @@ if nargin < 7
     saveRaw = false;
 end
 
-removeRejectedSpikes = false;
+removeRejectedSpikes = true;
 
 makeOutputPath(cscFiles, outputPath, skipExist)
 outputFiles = cell(size(cscFiles, 1), 1);
@@ -46,7 +46,7 @@ parfor i = 1: size(cscFiles, 1)
 
         fprintf('index of last spike: %d\n', (spikeTimestamps(end) - timestamps(1)) * (seconds(1) / samplingInterval));
     
-        cscSignalSpikesRemoved  = removeSpikes(cscSignal, timestamps, spikes, spikeClass, spikeTimestamps, true);
+        % cscSignalSpikesRemoved  = removeSpikes(cscSignal, timestamps, spikes, spikeClass, spikeTimestamps, true);
         [cscSignalSpikeInterpolated, spikeIntervalPercentage, interpolateIndex, spikeIndex] = interpolateSpikes(cscSignal, timestamps, spikes, spikeTimestamps);
         
         if removeRejectedSpikes
@@ -79,7 +79,7 @@ parfor i = 1: size(cscFiles, 1)
 
     if saveRaw
         lfpFileObj.cscSignal = cscSignal;
-        lfpFileObj.cscSignalSpikesRemoved = cscSignalSpikesRemoved;
+        % lfpFileObj.cscSignalSpikesRemoved = cscSignalSpikesRemoved;
         lfpFileObj.cscSignalSpikeInterpolated = cscSignalSpikeInterpolated;
         lfpFileObj.rawTimestamps = timestamps;
         lfpFileObj.interpolateIndex = interpolateIndex;

--- a/scripts/run_extractLFP.m
+++ b/scripts/run_extractLFP.m
@@ -1,30 +1,31 @@
 % run_extractLFP
 clear
 
-expId = 4;
-filePath = '/Users/XinNiuAdmin/Documents/NWBTest/output/MovieParadigm/570_MovieParadigm';
-
-% expId = 2;
-% filePath = '/Users/XinNiuAdmin/Documents/NWBTest/output/Screening/569_Screening';
+expIds = (3:11);
+filePath = '/Users/XinNiuAdmin/Documents/NWBTest/output/MovieParadigm/573_MovieParadigm';
 
 % 0: will remove all previous unpack files.
 % 1: skip existing files.
-skipExist = 0; 
+skipExist = 0;
 saveRaw = 1;
 
-expFilePath = [filePath, sprintf('/Experiment%d/', expId)];
+spikeFilePath = [filePath, '/Experiment', sprintf('-%d', expIds)];
 microLFPPath = fullfile(expFilePath, 'LFP_micro');
 
 %% micro electrodes:
+microFiles = [];
+timestampFiles = [];
+for i = 1: length(expIds)
+    expId = expIds(i);
+    cscFilePath = [filePath, sprintf('/Experiment%d', expId)];
+    microFilePath = fullfile(cscFilePath, 'CSC_micro');
+    microFiles = [microFiles, readcell(fullfile(microFilePath, 'outFileNames.csv'), Delimiter=",")];
 
-microFilePath = fullfile(expFilePath, 'CSC_micro');
-microFiles = readcell(fullfile(microFilePath, 'outFileNames.csv'), Delimiter=",");
-% microFiles = microFiles(2,:);
+    timestampFiles = dir(fullfile(microFilePath, 'lfpTimeStamps*.mat'));
+    timestampFiles = [timestampFiles, fullfile(microFilePath, {timestampFiles.name})];
+end
 
-timestampFiles = dir(fullfile(microFilePath, 'lfpTimeStamps*.mat'));
-timestampFiles = fullfile(microFilePath, {timestampFiles.name});
-
-spikeFilePath = fullfile(expFilePath, 'CSC_micro_spikes');
+spikeFilePath = fullfile(spikeFilePath, 'CSC_micro_spikes');
 [~, spikeFiles] = createSpikeFileName(microFiles(:, 1));
 spikeFiles = cellfun(@(x) fullfile(spikeFilePath, x), spikeFiles, UniformOutput=false);
 

--- a/scripts/run_extractLFP.m
+++ b/scripts/run_extractLFP.m
@@ -7,7 +7,7 @@ filePath = '/Users/XinNiuAdmin/Documents/NWBTest/output/MovieParadigm/573_MovieP
 % 0: will remove all previous unpack files.
 % 1: skip existing files.
 skipExist = 0;
-saveRaw = 1;
+saveRaw = false;
 
 spikeFilePath = [filePath, '/Experiment', sprintf('-%d', expIds)];
 microLFPPath = fullfile(expFilePath, 'LFP_micro');

--- a/scripts/run_screening.m
+++ b/scripts/run_screening.m
@@ -1,7 +1,7 @@
 clear
 
 patient = 573;
-exp = 1;
+exp = 13;
 
 trialFolder = sprintf('/Users/XinNiuAdmin/HoffmanMount/data/PIPELINE_vc/ANALYSIS/Screening/%d_Screening/Experiment%d/CSC_data', patient, exp);
 
@@ -10,8 +10,7 @@ rmpath(genpath('/Users/XinNiuAdmin/Documents/MATLAB/DataPipeline_Screening/Utili
 
 %% unpack data (only for Iowa data):
 
-% dataFolder='/Volumes/DATA/NLData/i720R/720-098_UCLA_Screening1/2024-04-29_14-41-45';
-dataFolder='/Volumes/DATA/NLData/D573/EXP1_Screening';
+dataFolder='/Volumes/DATA/NLData/i720R/720-098_UCLA_Screening1/2024-04-29_14-41-45';
 
 if ~exist(trialFolder, "dir")
     mkdir(trialFolder)
@@ -52,8 +51,8 @@ automaticScreeningAnalyze5(trialFolder);
 imageDirectory = sprintf('/Users/XinNiuAdmin/HoffmanMount/data/PIPELINE_vc/ANALYSIS/Screening/%d_Screening/Experiment%d/trial1', patient, exp);
 
 updateChannelMetaData(patient, exp)
-[clusterCharacteristics] = calculateClusterCharacteristics(patient, exp, 1, trialFolder);
-% [clusterCharacteristics] = calculateClusterCharacteristics_video(patient, exp, 1, imageDirectory);
+% [clusterCharacteristics] = calculateClusterCharacteristics(patient, exp, 1, trialFolder);
+[clusterCharacteristics] = calculateClusterCharacteristics_video(patient, exp, 1, imageDirectory);
 
 %%
 
@@ -73,11 +72,10 @@ rasters_by_image(patient, exp, imageDirectory, 0);
 
 %%
 
-rasters_by_unit_video(patient, exp, imageDirectory, 1, 0)
+% rasters_by_unit_video(patient, exp, imageDirectory, 1, 0)
 rasters_by_unit_video(patient, exp, imageDirectory, 0, 0)
+rasters_by_image(patient, exp, imageDirectory, 0);
 
-% rasters_by_unit(patient, exp, imageDirectory, 1, 1)
-% rasters_by_unit(patient, exp, imageDirectory, 0, 1)
 
 
 function save_aux(i, data, time0, timeend, samplingInterval, outputDir)

--- a/scripts/run_spikeSorting.m
+++ b/scripts/run_spikeSorting.m
@@ -13,13 +13,16 @@ skipExist = 1;
 
 microFiles = [];
 timestampFiles = [];
+expNamesId = 1;
+
 for i = 1:length(expIds)
     expFilePath = [filePath, '/Experiment', sprintf('%d/', expIds(i))];
     microFilePath = fullfile(expFilePath, 'CSC_micro');
     microFiles = [microFiles, readcell(fullfile(microFilePath, 'outFileNames.csv'), Delimiter=",")];
     timestampFile = dir(fullfile(microFilePath, 'lfpTimeStamps*.mat'));
     timestampFiles = [timestampFiles, fullfile(microFilePath, {timestampFile.name})];
-    expNames{i} = sprintf('Exp%d', expIds(i));
+    expNames(expNamesId: length(timestampFiles)) = {sprintf('Exp%d', expIds(i))};
+    expNamesId = length(timestampFiles) + 1;
 end
 
 

--- a/scripts/run_spikeSorting.m
+++ b/scripts/run_spikeSorting.m
@@ -28,7 +28,7 @@ end
 
 %% spike detection:
 delete(gcp('nocreate'))
-parpool(2);
+parpool(3);
 
 expFilePath = [filePath, '/Experiment', sprintf('-%d', expIds)];
 

--- a/scripts/runtest_extractLFP.m
+++ b/scripts/runtest_extractLFP.m
@@ -1,0 +1,35 @@
+% run_extractLFP
+clear
+
+expId = 4;
+filePath = '/Users/XinNiuAdmin/Documents/NWBTest/output/MovieParadigm/570_MovieParadigm';
+
+% expId = 2;
+% filePath = '/Users/XinNiuAdmin/Documents/NWBTest/output/Screening/569_Screening';
+
+% 0: will remove all previous unpack files.
+% 1: skip existing files.
+skipExist = 0; 
+saveRaw = 1;
+
+expFilePath = [filePath, sprintf('/Experiment%d/', expId)];
+microLFPPath = fullfile(expFilePath, 'LFP_micro');
+
+%% micro electrodes:
+
+microFilePath = fullfile(expFilePath, 'CSC_micro');
+microFiles = readcell(fullfile(microFilePath, 'outFileNames.csv'), Delimiter=",");
+% microFiles = microFiles(2,:);
+
+timestampFiles = dir(fullfile(microFilePath, 'lfpTimeStamps*.mat'));
+timestampFiles = fullfile(microFilePath, {timestampFiles.name});
+
+spikeFilePath = fullfile(expFilePath, 'CSC_micro_spikes');
+[~, spikeFiles] = createSpikeFileName(microFiles(:, 1));
+spikeFiles = cellfun(@(x) fullfile(spikeFilePath, x), spikeFiles, UniformOutput=false);
+
+lfpFiles = extractLFP(microFiles, timestampFiles, spikeFiles, microLFPPath, '', skipExist, saveRaw);
+writecell(lfpFiles, fullfile(microLFPPath, 'lfpFiles.csv'));
+
+
+

--- a/spikeDetection.m
+++ b/spikeDetection.m
@@ -62,7 +62,7 @@ parfor i = 1: size(cscFiles, 1)
 
     fprintf('write spikes to file:\n %s\n', spikeFilename);
     % remove file if it exist as repetitive writing to save variable in
-    % matfile obj consumes increasing memory:
+    % matfile obj consumes increasing storage:
     if exist(spikeFilename, "file")
         delete(spikeFilename);
     end

--- a/spikeDetection.m
+++ b/spikeDetection.m
@@ -69,7 +69,9 @@ parfor i = 1: size(cscFiles, 1)
 
     matobj = matfile(spikeFilename, 'Writable', true);
     matobj.spikes = vertcat(spikes{:});
+    clear spikes;
     matobj.spikeTimestamps = [spikeTimestamps{:}];
+    clear spikeTimestamps;
     matobj.thr = thr;
     matobj.param = param;
     matobj.spikeCodes = vertcat(spikeCodes{:});

--- a/spikeDetection.m
+++ b/spikeDetection.m
@@ -18,16 +18,16 @@ makeOutputPath(cscFiles, outputPath, skipExist)
 nSegments = length(timestampFiles);
 
 parfor i = 1: size(cscFiles, 1)
-    channelFiles = cscFiles(i,:);
-    fprintf(['spike detection: \n', sprintf('%s \n', channelFiles{:})])
 
+    channelFiles = cscFiles(i,:);
     spikeFilename = createSpikeFileName(channelFiles{1});
     spikeFilename = fullfile(outputPath, spikeFilename);
-
+    
     % TO DO: check file completeness:
     if exist(spikeFilename, "file") && skipExist
         continue
     end
+    fprintf(['spike detection: \n', sprintf('%s \n', channelFiles{:})])
 
     spikes = cell(nSegments, 1);
     spikeCodes = cell(nSegments, 1);
@@ -69,9 +69,9 @@ parfor i = 1: size(cscFiles, 1)
 
     matobj = matfile(spikeFilename, 'Writable', true);
     matobj.spikes = vertcat(spikes{:});
-    clear spikes;
+    % clear spikes;
     matobj.spikeTimestamps = [spikeTimestamps{:}];
-    clear spikeTimestamps;
+    % clear spikeTimestamps;
     matobj.thr = thr;
     matobj.param = param;
     matobj.spikeCodes = vertcat(spikeCodes{:});

--- a/spikeDetection.m
+++ b/spikeDetection.m
@@ -67,19 +67,25 @@ parfor i = 1: size(cscFiles, 1)
         delete(spikeFilename);
     end
 
-    matobj = matfile(spikeFilename, 'Writable', true);
-    matobj.spikes = vertcat(spikes{:});
-    % clear spikes;
-    matobj.spikeTimestamps = [spikeTimestamps{:}];
-    % clear spikeTimestamps;
-    matobj.thr = thr;
-    matobj.param = param;
-    matobj.spikeCodes = vertcat(spikeCodes{:});
-    matobj.spikeHist = [spikeHist{:}];
-    matobj.spikeHistPrecise = [spikeHistPrecise{:}];
-
-    if saveXfDetect
-        matobj.xfDetect = [xfDetect{:}];
+    try
+        matobj = matfile(spikeFilename, 'Writable', true);
+        matobj.spikes = vertcat(spikes{:});
+        % clear spikes;
+        matobj.spikeTimestamps = [spikeTimestamps{:}];
+        % clear spikeTimestamps;
+        matobj.thr = thr;
+        matobj.param = param;
+        matobj.spikeCodes = vertcat(spikeCodes{:});
+        matobj.spikeHist = [spikeHist{:}];
+        matobj.spikeHistPrecise = [spikeHistPrecise{:}];
+    
+        if saveXfDetect
+            matobj.xfDetect = [xfDetect{:}];
+        end
+    catch err
+        fprintf('delete file with writing error: %s', spikeFilename)
+        delete(spikeFilename);
+        rethrow(err)
     end
 
 end


### PR DESCRIPTION
in the lfp extraction pipeline, we compare different methods to remove spikes (interpolation vs remove average spikes). Remove average spikes is not used in data processing so it is commented. This also contains a bug fix on experiment Names (exp 9 has multiple data segments so expNames needs to be modified accordingly.