### PR TITLE
bug fix on linearize ts

### DIFF
--- a/utils/antiAliasing.m
+++ b/utils/antiAliasing.m
@@ -48,10 +48,10 @@ if Fs ~= downsampleFs
     % for interp1 to fill time gaps with add a NaN between data from each recording 
     % and add a corresponding timestamp to the time
     % but we only want to do this if there is a time gap between the recordings
-    
+    % 
     % create a 2kHz time vector that spans the full series
-    ts_2k = linearizeTimestamps(timestamps, downsampleFs);
-    
+    % ts_2k = linearizeTimestamps(timestamps, downsampleFs);
+    % 
     % Or use decimate or decimateBy (Emily) to downsample the signal?
     lfpSignal = interp1(timestamps, flt_data_conc, ts_2k);
     startTs = ts_2k(1);

--- a/utils/combineCSC.m
+++ b/utils/combineCSC.m
@@ -10,7 +10,7 @@ if nargin < 3 || isempty(maxGapDuration)
 end
 
 if nargin < 4
-    useSinglePrecision = false;
+    useSinglePrecision = true;
 end
 
 GAP_THRESHOLD = 2;
@@ -63,7 +63,7 @@ timestamps = timestamps - timestamps(1);
 if useSinglePrecision
     % large number lose precision so we save relative timestamps if use
     % single precision.
-    timestampsSingle = single(timestamps - timestamps(1));
+    timestampsSingle = single(timestamps);
     if ~any(diff(timestampsSingle)==0)
         timestamps = timestampsSingle;
     end

--- a/utils/extractLFP.m
+++ b/utils/extractLFP.m
@@ -84,7 +84,7 @@ for i = 1: numFiles
         cscSignalSpikeInterpolated = cscSignal;
         spikeIntervalPercentage = 0;
         interpolateIndex = false(1, length(cscSignal));
-        spikeGapLength = findGapLength(interpolateIndex);
+        spikeGapLength = [];
         spikeIndex = false(1, length(cscSignal));
     end
 

--- a/utils/linearizeTimestamps.m
+++ b/utils/linearizeTimestamps.m
@@ -13,11 +13,11 @@ function timestampsOut = linearizeTimestamps(timestampsIn, Fs)
         return
     end
 
-    gapIdx = [1, gapIdx, length(timestampsIn)];
+    gapIdx = [0, gapIdx, length(timestampsIn)];
     timestampsOut = cell(1, length(gapIdx) - 1);
     for i = 2: length(gapIdx)
         if gapIdx(i) - gapIdx(i-1) >= minIntervalLength
-            timestampsOut{i-1} = timestampsIn(gapIdx(i-1)): samplingInterval: timestampsIn(gapIdx(i));
+            timestampsOut{i-1} = timestampsIn(gapIdx(i-1)+1): samplingInterval: timestampsIn(gapIdx(i));
         else
             timestampsOut{i-1} = [];
         end


### PR DESCRIPTION
timestamps are not correctly calculated on LFP extraction. This is due to an incorrect start index at timestamp gaps.