### PR TITLE
[BUG] fix config issues in skipped micro channels

### DIFF
--- a/scripts/run_screening.m
+++ b/scripts/run_screening.m
@@ -39,7 +39,9 @@ spikeFilePath = [filePath, '/Experiment', sprintf('-%d', expId), '/CSC_micro_spi
 outputPath = [sprintf('/Users/XinNiuAdmin/Library/CloudStorage/Box-Box/Screening Rasters/Patient%d/screening_exp', patient), sprintf('-%d', expId)];
 
 % make sure not skip step 3 if spikeFilePath is changed.  
-skipExist = [1, 1, 0];
+skipExist = [1, 1, 1];
+
+maxNumCompThreads = 5;
 
 %% parse TTLs:
 % this will create TTL.mat and trialStruct.mat
@@ -73,15 +75,15 @@ end
 
 %%
 % generate rasters plots by units for image and audio stimuli:
-rasters_by_unit(patient, expFilePath, imageDirectory, 1, 'stim', targetLabel, outputPath);
-rasters_by_unit(patient, expFilePath, imageDirectory, 0, 'stim', targetLabel, outputPath);
+% rasters_by_unit(patient, expFilePath, imageDirectory, 1, 'stim', targetLabel, outputPath);
+% rasters_by_unit(patient, expFilePath, imageDirectory, 0, 'stim', targetLabel, outputPath);
 
 % generate raster plots by units for video stimuli:
 % rasters_by_unit(patient, expFilePath, imageDirectory, 1, 'video', targetLabel, outputPath);
 % rasters_by_unit(patient, expFilePath, imageDirectory, 0, 'video', targetLabel, outputPath);
 
 % generate raster plots organized by image:
-rasters_by_image(patient, expFilePath, imageDirectory, targetLabel, outputPath);
+% rasters_by_image(patient, expFilePath, imageDirectory, targetLabel, outputPath);
 
 % generate raster plots with response time as onset:
 rasters_by_unit(patient, expFilePath, imageDirectory, 1, 'response', targetLabel, outputPath);

--- a/scripts/run_screening.m
+++ b/scripts/run_screening.m
@@ -8,7 +8,6 @@ patient = 581;
 expId = [1];
 
 filePath = sprintf('/Users/XinNiuAdmin/HoffmanMount/data/PIPELINE_vc/ANALYSIS/Screening/%d_Screening', patient);
-skipExist = [1, 1, 1];
 
 % set target local for each micro channel:
 targetLabel.GA1 = ''; 
@@ -36,13 +35,14 @@ ttlLogFiles = {
 
 imageDirectory = '/Users/XinNiuAdmin/Library/CloudStorage/Box-Box/Screening/D581/Screening1/trial1';
 expFilePath = [filePath, '/Experiment', sprintf('-%d', expId)];
-spikeFilePath = [filePath, '/Experiment', sprintf('-%d', expId), '/CSC_micro_spikes_removePLI-0_CAR-1_rejectNoiseSpikes-1'];
+spikeFilePath = [filePath, '/Experiment', sprintf('-%d', expId), '/CSC_micro_spikes_removePLI-1_CAR-1_rejectNoiseSpikes-1'];
 outputPath = [sprintf('/Users/XinNiuAdmin/Library/CloudStorage/Box-Box/Screening Rasters/Patient%d/screening_exp', patient), sprintf('-%d', expId)];
 
+% make sure not skip step 3 if spikeFilePath is changed.  
+skipExist = [1, 1, 0];
 
 %% parse TTLs:
 % this will create TTL.mat and trialStruct.mat
-% expFilePath = [filePath, '/Experiment', sprintf('-%d', expId)];
 
 if ~exist(fullfile(expFilePath, 'TTLs.mat'), "file") || ~skipExist(1)
     eventFile = fullfile(expFilePath, 'CSC_events/Events_001.mat');
@@ -73,8 +73,8 @@ end
 
 %%
 % generate rasters plots by units for image and audio stimuli:
-% rasters_by_unit(patient, expFilePath, imageDirectory, 1, 'stim', targetLabel, outputPath);
-% rasters_by_unit(patient, expFilePath, imageDirectory, 0, 'stim', targetLabel, outputPath);
+rasters_by_unit(patient, expFilePath, imageDirectory, 1, 'stim', targetLabel, outputPath);
+rasters_by_unit(patient, expFilePath, imageDirectory, 0, 'stim', targetLabel, outputPath);
 
 % generate raster plots by units for video stimuli:
 % rasters_by_unit(patient, expFilePath, imageDirectory, 1, 'video', targetLabel, outputPath);
@@ -84,7 +84,7 @@ end
 rasters_by_image(patient, expFilePath, imageDirectory, targetLabel, outputPath);
 
 % generate raster plots with response time as onset:
-% rasters_by_unit(patient, expFilePath, imageDirectory, 1, 'response', targetLabel, outputPath);
-% rasters_by_unit(patient, expFilePath, imageDirectory, 0, 'response', targetLabel, outputPath);
+rasters_by_unit(patient, expFilePath, imageDirectory, 1, 'response', targetLabel, outputPath);
+rasters_by_unit(patient, expFilePath, imageDirectory, 0, 'response', targetLabel, outputPath);
 
 %%

--- a/src/montageConfig/MontageConfigUI.m
+++ b/src/montageConfig/MontageConfigUI.m
@@ -382,8 +382,8 @@ function MontageConfigUI()
 
                     if str2double(micros) > 0
                         microChannels = [microChannels, {brainLabel}];
-                    % else
-                    %     microChannels = [microChannels, {""}];
+                    else
+                        microChannels = [microChannels, {""}];
                     end
                 end
             end

--- a/src/montageConfig/MontageConfigUI.m
+++ b/src/montageConfig/MontageConfigUI.m
@@ -383,7 +383,7 @@ function MontageConfigUI()
                     if str2double(micros) > 0
                         microChannels = [microChannels, {brainLabel}];
                     else
-                        microChannels = [microChannels, {""}];
+                        microChannels = [microChannels, {''}];
                     end
                 end
             end

--- a/src/montageConfig/generatePegasusConfigFile.m
+++ b/src/montageConfig/generatePegasusConfigFile.m
@@ -7,7 +7,7 @@ function generatePegasusConfigFile(patientNum, macroList, macroNumChannels,...
 macroNumChannels = macroNumChannels(:)';
 
 if ~exist('savePath','var')|| isempty(savePath)
-    savePath = sprintf('%d_InitialGuess.cfg',patientNum);
+    savePath = sprintf('%d_InitialGuess.cfg', patientNum);
 end
 
 if ~exist('miscMacros','var')|| isempty(miscMacros)

--- a/src/montageConfig/generatePegasusConfigFile.m
+++ b/src/montageConfig/generatePegasusConfigFile.m
@@ -11,10 +11,13 @@ if ~exist('savePath','var')|| isempty(savePath)
 end
 
 if ~exist('miscMacros','var')|| isempty(miscMacros)
-    miscMacros = {'C3','C4','PZ','Ez',...% used to include 'GlobalMicroRef'but decided to remove
+    miscMacros = {
+        'C3','C4','PZ','Ez',... % used to include 'GlobalMicroRef'but decided to remove
         'EOG1','EOG2','EMG1','EMG2','A1','A2',...
-        'MICROPHONE','HR_Ref','HR','TTLRef','TTLSync',...
-        'Analogue1','Analogue2'};
+        ... 'MICROPHONE',...
+        'HR_Ref','HR','TTLRef','TTLSync',...
+        'Analogue2','Analogue3'
+        };
 end
 
 if ~exist('microsToDuplicateList', 'var')||isempty(microsToDuplicateList)
@@ -43,7 +46,7 @@ if ~isempty(macroList)
         addMacrosToConfig(fid2, startsAt(i), macroList{i}, macroNumChannels(i));
     end
 
-    miscStart = startsAt(end)+macroNumChannels(end);
+    miscStart = startsAt(end) + macroNumChannels(end);
     for i=1:length(miscMacros)
         addMiscToConfig(fid, miscStart+i-1, miscMacros{i});
     end
@@ -97,7 +100,9 @@ for i=1:length(sleepMacros)
 end
 
 % Microphone etc
-extraPlots = {'MICROPHONE','TTLSync','HR'};
+% extraPlots = {'MICROPHONE','TTLSync','HR'};
+extraPlots = {'TTLSync', 'HR'};
+
 setUpTimeWindow(fid, 'Additional Plots')
 for i=1:length(extraPlots)
     addCSCtoPlotWindow(fid, extraPlots{i}, 'Additional Plots');
@@ -106,25 +111,26 @@ end
 setUpSpikeWindow(fid);
 for i=1:length(microList)
     if ~isempty(microList{i})
-        addToSpikeWindow(fid,microList{i},allPossibleMicros{i});
+        addToSpikeWindow(fid, microList{i}, allPossibleMicros{i});
     end
 end
-addFinalPointsToConfig(fid,2);
-addFinalPointsToConfig(fid2,2);
+addFinalPointsToConfig(fid, 2);
+addFinalPointsToConfig(fid2, 2);
 fclose(fid);
 fclose(fid2);
 
-function makeBaseOfConfigFile(fid,patientNum)
+
+function makeBaseOfConfigFile(fid, patientNum)
 
 fprintf(fid,'#Pegasus system setup file\n');
 fprintf(fid,'#Generated using Emily''s Generator\n');
-fprintf(fid,'#File Generation Date:(yyyy/mm/dd hh:mm:ss) %s\n',datestr(now,'yyyy/mm/dd HH:MM:SS'));
+fprintf(fid,'#File Generation Date:(yyyy/mm/dd hh:mm:ss) %s\n', datestr(now, 'yyyy/mm/dd HH:MM:SS'));
 fprintf(fid,'\n');
 fprintf(fid,'#System Options Setup\n');
 fprintf(fid,'-SetSystemIdentifier "CNLNEURALYNX"\n');
 fprintf(fid,'\n');
 fprintf(fid,'#Acquisition Control Setup\n');
-fprintf(fid,'-SetDataDirectory "E:\\ATLASData\\D%d\\"\n',patientNum);
+fprintf(fid,'-SetDataDirectory "E:\\ATLASData\\D%d\\"\n', patientNum);
 fprintf(fid,'-SetCreateNewFilesPerRecording True\n');
 fprintf(fid,'-SetMaxFileLength 2\n');
 fprintf(fid,'\n');
@@ -247,8 +253,8 @@ function addMacrosToConfig(fid,startAt,macroName,maxCh)
 
 for i=1:maxCh
     thisChannel = startAt+i-1;
-    thisStr = sprintf('%s%d',macroName,i);
-    thisRef = floor(thisChannel/32);%floor(thisChannel/32)*2+1;
+    thisStr = sprintf('%s%d', macroName, i);
+    thisRef = floor(thisChannel/32); %floor(thisChannel/32)*2+1;
     fprintf(fid,'#Acquisition Entity creation and setup for: "%s"\n',thisStr);
     fprintf(fid,'-CreateCscAcqEnt "%s" "AcqSystem1"\n',thisStr);
     fprintf(fid,'-SetAcqEntProcessingEnabled "%s" True\n',thisStr);
@@ -268,7 +274,7 @@ for i=1:maxCh
     fprintf(fid,'\n');
 end
 
-function addMiscToConfig(fid,thisChannel,miscName)
+function addMiscToConfig(fid, thisChannel, miscName)
 
 %     miscMacros = {'C3','C4','PZ','Ez','GlobalMicroRef',...
 %         'EOG1','EOG2','EMG1','EMG2','A1','A2',...
@@ -276,10 +282,12 @@ function addMiscToConfig(fid,thisChannel,miscName)
 %         'Analogue1','Analogue2'};
 
 switch miscName
-    case 'Analogue1'
-        thisChannel = 224;
+    % case 'Analogue1'
+    %     thisChannel = 224;
     case 'Analogue2'
         thisChannel = 225;
+    case 'Analogue3'
+        thisChannel = 226;
     otherwise
         %nothing to do, thisChannel is as was sent to the function
 end
@@ -287,16 +295,16 @@ end
 thisRef = floor(thisChannel/32);%*2+1;
 
 
-fprintf(fid,'#Acquisition Entity creation and setup for: "%s"\n',miscName);
-fprintf(fid,'-CreateCscAcqEnt "%s" "AcqSystem1"\n',miscName);
+fprintf(fid,'#Acquisition Entity creation and setup for: "%s"\n', miscName);
+fprintf(fid,'-CreateCscAcqEnt "%s" "AcqSystem1"\n', miscName);
 if ismember(miscName,...
-        {'Analogue1','Analogue2','EOG1','EOG2','EMG1','EMG2',...
+        {'Analogue2','Analogue3','EOG1','EOG2','EMG1','EMG2',...
         'A1','A2','TTLSync','TTLRef'}) %HR2, TTLRef
-    fprintf(fid,'-SetAcqEntProcessingEnabled "%s" False\n',miscName);
+    fprintf(fid,'-SetAcqEntProcessingEnabled "%s" False\n', miscName);
 else
-    fprintf(fid,'-SetAcqEntProcessingEnabled "%s" True\n',miscName);
+    fprintf(fid,'-SetAcqEntProcessingEnabled "%s" True\n', miscName);
 end
-fprintf(fid,'-SetChannelNumber "%s" %d\n',miscName,thisChannel);
+fprintf(fid,'-SetChannelNumber "%s" %d\n', miscName, thisChannel);
 
 switch miscName
     case 'MICROPHONE'
@@ -310,7 +318,10 @@ end
 if ismember(miscName,{'MICROPHONE','GlobalMicroRef'})
     fprintf(fid,'-SetInputRange "%s" 5000\n',miscName);
     fprintf(fid,'-SetSubSamplingInterleave "%s" 1\n',miscName);
-elseif ismember(miscName,{'Analogue1','Analogue2'})
+elseif ismember(miscName,{'Analogue2'})
+    fprintf(fid,'-SetInputRange "%s" 800\n',miscName);
+    fprintf(fid,'-SetSubSamplingInterleave "%s" 1\n',miscName);
+elseif ismember(miscName,{'Analogue3'})
     fprintf(fid,'-SetInputRange "%s" 1500\n',miscName);
     fprintf(fid,'-SetSubSamplingInterleave "%s" 1\n',miscName);
 else
@@ -321,7 +332,7 @@ fprintf(fid,'-SetDspLowCutFilterEnabled "%s" True\n',miscName);
 fprintf(fid,'-SetDspLowCutFrequency "%s" 0.1\n',miscName);
 fprintf(fid,'-SetDspLowCutNumberTaps "%s" 0\n',miscName);
 fprintf(fid,'-SetDspHighCutFilterEnabled "%s" True\n',miscName);
-if ismember(miscName,{'MICROPHONE','GlobalMicroRef','Analogue1','Analogue2'})
+if ismember(miscName,{'MICROPHONE', 'GlobalMicroRef', 'Analogue2', 'Analogue3'})
     fprintf(fid,'-SetDspHighCutFrequency "%s" 8000\n',miscName);
 else
     fprintf(fid,'-SetDspHighCutFrequency "%s" 500\n',miscName);
@@ -527,9 +538,9 @@ fprintf(fid,'-SetPlotWindowShowTitleBar "Spike Window 1" True\n');
 fprintf(fid,'\n');
 fprintf(fid,'# Plot addition and setup for "Spike Window 1"\n');
 
-function addToSpikeWindow(fid,microName,microID)
+function addToSpikeWindow(fid,microName, microID)
 for i=1:8
-    thisStr = sprintf('SE%s-%s%d',microID,microName,i);
+    thisStr = sprintf('SE%s-%s%d', microID, microName, i);
     fprintf(fid,'-AddPlot "Spike Window 1" "%s"\n',thisStr);
     fprintf(fid,'-SetPlotEnabled "Spike Window 1" "%s" True\n',thisStr);
     for d = 0:31

--- a/src/montageConfig/generatePegasusConfigFile.m
+++ b/src/montageConfig/generatePegasusConfigFile.m
@@ -54,7 +54,9 @@ end
 % end
 
 for i=1:length(microList)
-    addSpikesToConfig(fid, i, microList{i}, allPossibleMicros{i});
+    if ~isempty(microList{i})
+        addSpikesToConfig(fid, i, microList{i}, allPossibleMicros{i});
+    end
 end
 
 addFinalPointsToConfig(fid, 1);
@@ -63,12 +65,14 @@ addFinalPointsToConfig(fid2, 1);
 % Micro Window
 setUpTimeWindow(fid,'Micro Window');
 for i=1:length(microList)
-    addCSCtoPlotWindow(fid, microList{i}, allPossibleMicros{i});
+    if ~isempty(microList{i})
+        addCSCtoPlotWindow(fid, microList{i}, allPossibleMicros{i});
+    end
 end
 
 setUpTimeWindow(fid,'Alternate Reference Micro Window');
 for i=1:length(microList)
-    if ismember(microList{i}, microsToDuplicateList)
+    if ~isempty(microList{i}) && ismember(microList{i}, microsToDuplicateList)
         addCSCtoPlotWindow(fid, microList{i}, 'AltRef');
     end
 end
@@ -101,7 +105,9 @@ end
 
 setUpSpikeWindow(fid);
 for i=1:length(microList)
-    addToSpikeWindow(fid,microList{i},allPossibleMicros{i});
+    if ~isempty(microList{i})
+        addToSpikeWindow(fid,microList{i},allPossibleMicros{i});
+    end
 end
 addFinalPointsToConfig(fid,2);
 addFinalPointsToConfig(fid2,2);

--- a/test/montage_config/config_Patient-999_exp-1_2025-02-10_19-26-39.cfg
+++ b/test/montage_config/config_Patient-999_exp-1_2025-02-10_19-26-39.cfg
@@ -1,0 +1,5770 @@
+#Pegasus system setup file
+#Generated using Emily's Generator
+#File Generation Date:(yyyy/mm/dd hh:mm:ss) 2025/02/10 19:26:39
+
+#System Options Setup
+-SetSystemIdentifier "CNLNEURALYNX"
+
+#Acquisition Control Setup
+-SetDataDirectory "E:\ATLASData\D999\"
+-SetCreateNewFilesPerRecording True
+-SetMaxFileLength 2
+
+#Hardware Subsystem Creation and Setup for:  AcqSystem1
+-CreateHardwareSubSystem "AcqSystem1" ATLAS "32000" "192.168.3.10" "26011" "192.168.3.100" "26090"
+-SetDialogPosition "Hardware" 0 42
+-SetDialogVisible "Hardware" False
+
+#Reference Manager Setup
+#Video Capture Setup
+
+#Acquisition Entity creation and setup for: Events
+-SetNetComDataBufferingEnabled Events False
+-SetNetComDataBufferSize Events 3000
+
+#Acquisition Entity creation and setup for: "GA1-LA1"
+-CreateCscAcqEnt "GA1-LA1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA1-LA1" True
+-SetChannelNumber "GA1-LA1" 128
+-SetAcqEntReference "GA1-LA1" 32000004
+-SetInputRange "GA1-LA1" 3000
+-SetSubSamplingInterleave "GA1-LA1" 1
+-SetDspLowCutFilterEnabled "GA1-LA1" True
+-SetDspLowCutFrequency "GA1-LA1" 0.1
+-SetDspLowCutNumberTaps "GA1-LA1" 0
+-SetDspHighCutFilterEnabled "GA1-LA1" True
+-SetDspHighCutFrequency "GA1-LA1" 8000
+-SetDspHighCutNumberTaps "GA1-LA1" 256
+-SetInputInverted "GA1-LA1" True
+-SetNetComDataBufferingEnabled "GA1-LA1" False
+-SetNetComDataBufferSize "GA1-LA1" 3000
+
+#Acquisition Entity creation and setup for: "GA1-LA2"
+-CreateCscAcqEnt "GA1-LA2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA1-LA2" True
+-SetChannelNumber "GA1-LA2" 129
+-SetAcqEntReference "GA1-LA2" 32000004
+-SetInputRange "GA1-LA2" 3000
+-SetSubSamplingInterleave "GA1-LA2" 1
+-SetDspLowCutFilterEnabled "GA1-LA2" True
+-SetDspLowCutFrequency "GA1-LA2" 0.1
+-SetDspLowCutNumberTaps "GA1-LA2" 0
+-SetDspHighCutFilterEnabled "GA1-LA2" True
+-SetDspHighCutFrequency "GA1-LA2" 8000
+-SetDspHighCutNumberTaps "GA1-LA2" 256
+-SetInputInverted "GA1-LA2" True
+-SetNetComDataBufferingEnabled "GA1-LA2" False
+-SetNetComDataBufferSize "GA1-LA2" 3000
+
+#Acquisition Entity creation and setup for: "GA1-LA3"
+-CreateCscAcqEnt "GA1-LA3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA1-LA3" True
+-SetChannelNumber "GA1-LA3" 130
+-SetAcqEntReference "GA1-LA3" 32000004
+-SetInputRange "GA1-LA3" 3000
+-SetSubSamplingInterleave "GA1-LA3" 1
+-SetDspLowCutFilterEnabled "GA1-LA3" True
+-SetDspLowCutFrequency "GA1-LA3" 0.1
+-SetDspLowCutNumberTaps "GA1-LA3" 0
+-SetDspHighCutFilterEnabled "GA1-LA3" True
+-SetDspHighCutFrequency "GA1-LA3" 8000
+-SetDspHighCutNumberTaps "GA1-LA3" 256
+-SetInputInverted "GA1-LA3" True
+-SetNetComDataBufferingEnabled "GA1-LA3" False
+-SetNetComDataBufferSize "GA1-LA3" 3000
+
+#Acquisition Entity creation and setup for: "GA1-LA4"
+-CreateCscAcqEnt "GA1-LA4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA1-LA4" True
+-SetChannelNumber "GA1-LA4" 131
+-SetAcqEntReference "GA1-LA4" 32000004
+-SetInputRange "GA1-LA4" 3000
+-SetSubSamplingInterleave "GA1-LA4" 1
+-SetDspLowCutFilterEnabled "GA1-LA4" True
+-SetDspLowCutFrequency "GA1-LA4" 0.1
+-SetDspLowCutNumberTaps "GA1-LA4" 0
+-SetDspHighCutFilterEnabled "GA1-LA4" True
+-SetDspHighCutFrequency "GA1-LA4" 8000
+-SetDspHighCutNumberTaps "GA1-LA4" 256
+-SetInputInverted "GA1-LA4" True
+-SetNetComDataBufferingEnabled "GA1-LA4" False
+-SetNetComDataBufferSize "GA1-LA4" 3000
+
+#Acquisition Entity creation and setup for: "GA1-LA5"
+-CreateCscAcqEnt "GA1-LA5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA1-LA5" True
+-SetChannelNumber "GA1-LA5" 132
+-SetAcqEntReference "GA1-LA5" 32000004
+-SetInputRange "GA1-LA5" 3000
+-SetSubSamplingInterleave "GA1-LA5" 1
+-SetDspLowCutFilterEnabled "GA1-LA5" True
+-SetDspLowCutFrequency "GA1-LA5" 0.1
+-SetDspLowCutNumberTaps "GA1-LA5" 0
+-SetDspHighCutFilterEnabled "GA1-LA5" True
+-SetDspHighCutFrequency "GA1-LA5" 8000
+-SetDspHighCutNumberTaps "GA1-LA5" 256
+-SetInputInverted "GA1-LA5" True
+-SetNetComDataBufferingEnabled "GA1-LA5" False
+-SetNetComDataBufferSize "GA1-LA5" 3000
+
+#Acquisition Entity creation and setup for: "GA1-LA6"
+-CreateCscAcqEnt "GA1-LA6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA1-LA6" True
+-SetChannelNumber "GA1-LA6" 133
+-SetAcqEntReference "GA1-LA6" 32000004
+-SetInputRange "GA1-LA6" 3000
+-SetSubSamplingInterleave "GA1-LA6" 1
+-SetDspLowCutFilterEnabled "GA1-LA6" True
+-SetDspLowCutFrequency "GA1-LA6" 0.1
+-SetDspLowCutNumberTaps "GA1-LA6" 0
+-SetDspHighCutFilterEnabled "GA1-LA6" True
+-SetDspHighCutFrequency "GA1-LA6" 8000
+-SetDspHighCutNumberTaps "GA1-LA6" 256
+-SetInputInverted "GA1-LA6" True
+-SetNetComDataBufferingEnabled "GA1-LA6" False
+-SetNetComDataBufferSize "GA1-LA6" 3000
+
+#Acquisition Entity creation and setup for: "GA1-LA7"
+-CreateCscAcqEnt "GA1-LA7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA1-LA7" True
+-SetChannelNumber "GA1-LA7" 134
+-SetAcqEntReference "GA1-LA7" 32000004
+-SetInputRange "GA1-LA7" 3000
+-SetSubSamplingInterleave "GA1-LA7" 1
+-SetDspLowCutFilterEnabled "GA1-LA7" True
+-SetDspLowCutFrequency "GA1-LA7" 0.1
+-SetDspLowCutNumberTaps "GA1-LA7" 0
+-SetDspHighCutFilterEnabled "GA1-LA7" True
+-SetDspHighCutFrequency "GA1-LA7" 8000
+-SetDspHighCutNumberTaps "GA1-LA7" 256
+-SetInputInverted "GA1-LA7" True
+-SetNetComDataBufferingEnabled "GA1-LA7" False
+-SetNetComDataBufferSize "GA1-LA7" 3000
+
+#Acquisition Entity creation and setup for: "GA1-LA8"
+-CreateCscAcqEnt "GA1-LA8" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA1-LA8" True
+-SetChannelNumber "GA1-LA8" 135
+-SetAcqEntReference "GA1-LA8" 32000004
+-SetInputRange "GA1-LA8" 3000
+-SetSubSamplingInterleave "GA1-LA8" 1
+-SetDspLowCutFilterEnabled "GA1-LA8" True
+-SetDspLowCutFrequency "GA1-LA8" 0.1
+-SetDspLowCutNumberTaps "GA1-LA8" 0
+-SetDspHighCutFilterEnabled "GA1-LA8" True
+-SetDspHighCutFrequency "GA1-LA8" 8000
+-SetDspHighCutNumberTaps "GA1-LA8" 256
+-SetInputInverted "GA1-LA8" True
+-SetNetComDataBufferingEnabled "GA1-LA8" False
+-SetNetComDataBufferSize "GA1-LA8" 3000
+
+#Acquisition Entity creation and setup for: "GA2-LAC1"
+-CreateCscAcqEnt "GA2-LAC1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA2-LAC1" True
+-SetChannelNumber "GA2-LAC1" 136
+-SetAcqEntReference "GA2-LAC1" 33000004
+-SetInputRange "GA2-LAC1" 3000
+-SetSubSamplingInterleave "GA2-LAC1" 1
+-SetDspLowCutFilterEnabled "GA2-LAC1" True
+-SetDspLowCutFrequency "GA2-LAC1" 0.1
+-SetDspLowCutNumberTaps "GA2-LAC1" 0
+-SetDspHighCutFilterEnabled "GA2-LAC1" True
+-SetDspHighCutFrequency "GA2-LAC1" 8000
+-SetDspHighCutNumberTaps "GA2-LAC1" 256
+-SetInputInverted "GA2-LAC1" True
+-SetNetComDataBufferingEnabled "GA2-LAC1" False
+-SetNetComDataBufferSize "GA2-LAC1" 3000
+
+#Acquisition Entity creation and setup for: "GA2-LAC2"
+-CreateCscAcqEnt "GA2-LAC2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA2-LAC2" True
+-SetChannelNumber "GA2-LAC2" 137
+-SetAcqEntReference "GA2-LAC2" 33000004
+-SetInputRange "GA2-LAC2" 3000
+-SetSubSamplingInterleave "GA2-LAC2" 1
+-SetDspLowCutFilterEnabled "GA2-LAC2" True
+-SetDspLowCutFrequency "GA2-LAC2" 0.1
+-SetDspLowCutNumberTaps "GA2-LAC2" 0
+-SetDspHighCutFilterEnabled "GA2-LAC2" True
+-SetDspHighCutFrequency "GA2-LAC2" 8000
+-SetDspHighCutNumberTaps "GA2-LAC2" 256
+-SetInputInverted "GA2-LAC2" True
+-SetNetComDataBufferingEnabled "GA2-LAC2" False
+-SetNetComDataBufferSize "GA2-LAC2" 3000
+
+#Acquisition Entity creation and setup for: "GA2-LAC3"
+-CreateCscAcqEnt "GA2-LAC3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA2-LAC3" True
+-SetChannelNumber "GA2-LAC3" 138
+-SetAcqEntReference "GA2-LAC3" 33000004
+-SetInputRange "GA2-LAC3" 3000
+-SetSubSamplingInterleave "GA2-LAC3" 1
+-SetDspLowCutFilterEnabled "GA2-LAC3" True
+-SetDspLowCutFrequency "GA2-LAC3" 0.1
+-SetDspLowCutNumberTaps "GA2-LAC3" 0
+-SetDspHighCutFilterEnabled "GA2-LAC3" True
+-SetDspHighCutFrequency "GA2-LAC3" 8000
+-SetDspHighCutNumberTaps "GA2-LAC3" 256
+-SetInputInverted "GA2-LAC3" True
+-SetNetComDataBufferingEnabled "GA2-LAC3" False
+-SetNetComDataBufferSize "GA2-LAC3" 3000
+
+#Acquisition Entity creation and setup for: "GA2-LAC4"
+-CreateCscAcqEnt "GA2-LAC4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA2-LAC4" True
+-SetChannelNumber "GA2-LAC4" 139
+-SetAcqEntReference "GA2-LAC4" 33000004
+-SetInputRange "GA2-LAC4" 3000
+-SetSubSamplingInterleave "GA2-LAC4" 1
+-SetDspLowCutFilterEnabled "GA2-LAC4" True
+-SetDspLowCutFrequency "GA2-LAC4" 0.1
+-SetDspLowCutNumberTaps "GA2-LAC4" 0
+-SetDspHighCutFilterEnabled "GA2-LAC4" True
+-SetDspHighCutFrequency "GA2-LAC4" 8000
+-SetDspHighCutNumberTaps "GA2-LAC4" 256
+-SetInputInverted "GA2-LAC4" True
+-SetNetComDataBufferingEnabled "GA2-LAC4" False
+-SetNetComDataBufferSize "GA2-LAC4" 3000
+
+#Acquisition Entity creation and setup for: "GA2-LAC5"
+-CreateCscAcqEnt "GA2-LAC5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA2-LAC5" True
+-SetChannelNumber "GA2-LAC5" 140
+-SetAcqEntReference "GA2-LAC5" 33000004
+-SetInputRange "GA2-LAC5" 3000
+-SetSubSamplingInterleave "GA2-LAC5" 1
+-SetDspLowCutFilterEnabled "GA2-LAC5" True
+-SetDspLowCutFrequency "GA2-LAC5" 0.1
+-SetDspLowCutNumberTaps "GA2-LAC5" 0
+-SetDspHighCutFilterEnabled "GA2-LAC5" True
+-SetDspHighCutFrequency "GA2-LAC5" 8000
+-SetDspHighCutNumberTaps "GA2-LAC5" 256
+-SetInputInverted "GA2-LAC5" True
+-SetNetComDataBufferingEnabled "GA2-LAC5" False
+-SetNetComDataBufferSize "GA2-LAC5" 3000
+
+#Acquisition Entity creation and setup for: "GA2-LAC6"
+-CreateCscAcqEnt "GA2-LAC6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA2-LAC6" True
+-SetChannelNumber "GA2-LAC6" 141
+-SetAcqEntReference "GA2-LAC6" 33000004
+-SetInputRange "GA2-LAC6" 3000
+-SetSubSamplingInterleave "GA2-LAC6" 1
+-SetDspLowCutFilterEnabled "GA2-LAC6" True
+-SetDspLowCutFrequency "GA2-LAC6" 0.1
+-SetDspLowCutNumberTaps "GA2-LAC6" 0
+-SetDspHighCutFilterEnabled "GA2-LAC6" True
+-SetDspHighCutFrequency "GA2-LAC6" 8000
+-SetDspHighCutNumberTaps "GA2-LAC6" 256
+-SetInputInverted "GA2-LAC6" True
+-SetNetComDataBufferingEnabled "GA2-LAC6" False
+-SetNetComDataBufferSize "GA2-LAC6" 3000
+
+#Acquisition Entity creation and setup for: "GA2-LAC7"
+-CreateCscAcqEnt "GA2-LAC7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA2-LAC7" True
+-SetChannelNumber "GA2-LAC7" 142
+-SetAcqEntReference "GA2-LAC7" 33000004
+-SetInputRange "GA2-LAC7" 3000
+-SetSubSamplingInterleave "GA2-LAC7" 1
+-SetDspLowCutFilterEnabled "GA2-LAC7" True
+-SetDspLowCutFrequency "GA2-LAC7" 0.1
+-SetDspLowCutNumberTaps "GA2-LAC7" 0
+-SetDspHighCutFilterEnabled "GA2-LAC7" True
+-SetDspHighCutFrequency "GA2-LAC7" 8000
+-SetDspHighCutNumberTaps "GA2-LAC7" 256
+-SetInputInverted "GA2-LAC7" True
+-SetNetComDataBufferingEnabled "GA2-LAC7" False
+-SetNetComDataBufferSize "GA2-LAC7" 3000
+
+#Acquisition Entity creation and setup for: "GA2-LAC8"
+-CreateCscAcqEnt "GA2-LAC8" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA2-LAC8" True
+-SetChannelNumber "GA2-LAC8" 143
+-SetAcqEntReference "GA2-LAC8" 33000004
+-SetInputRange "GA2-LAC8" 3000
+-SetSubSamplingInterleave "GA2-LAC8" 1
+-SetDspLowCutFilterEnabled "GA2-LAC8" True
+-SetDspLowCutFrequency "GA2-LAC8" 0.1
+-SetDspLowCutNumberTaps "GA2-LAC8" 0
+-SetDspHighCutFilterEnabled "GA2-LAC8" True
+-SetDspHighCutFrequency "GA2-LAC8" 8000
+-SetDspHighCutNumberTaps "GA2-LAC8" 256
+-SetInputInverted "GA2-LAC8" True
+-SetNetComDataBufferingEnabled "GA2-LAC8" False
+-SetNetComDataBufferSize "GA2-LAC8" 3000
+
+#Acquisition Entity creation and setup for: "GA3-LACd1"
+-CreateCscAcqEnt "GA3-LACd1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA3-LACd1" True
+-SetChannelNumber "GA3-LACd1" 144
+-SetAcqEntReference "GA3-LACd1" 34000004
+-SetInputRange "GA3-LACd1" 3000
+-SetSubSamplingInterleave "GA3-LACd1" 1
+-SetDspLowCutFilterEnabled "GA3-LACd1" True
+-SetDspLowCutFrequency "GA3-LACd1" 0.1
+-SetDspLowCutNumberTaps "GA3-LACd1" 0
+-SetDspHighCutFilterEnabled "GA3-LACd1" True
+-SetDspHighCutFrequency "GA3-LACd1" 8000
+-SetDspHighCutNumberTaps "GA3-LACd1" 256
+-SetInputInverted "GA3-LACd1" True
+-SetNetComDataBufferingEnabled "GA3-LACd1" False
+-SetNetComDataBufferSize "GA3-LACd1" 3000
+
+#Acquisition Entity creation and setup for: "GA3-LACd2"
+-CreateCscAcqEnt "GA3-LACd2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA3-LACd2" True
+-SetChannelNumber "GA3-LACd2" 145
+-SetAcqEntReference "GA3-LACd2" 34000004
+-SetInputRange "GA3-LACd2" 3000
+-SetSubSamplingInterleave "GA3-LACd2" 1
+-SetDspLowCutFilterEnabled "GA3-LACd2" True
+-SetDspLowCutFrequency "GA3-LACd2" 0.1
+-SetDspLowCutNumberTaps "GA3-LACd2" 0
+-SetDspHighCutFilterEnabled "GA3-LACd2" True
+-SetDspHighCutFrequency "GA3-LACd2" 8000
+-SetDspHighCutNumberTaps "GA3-LACd2" 256
+-SetInputInverted "GA3-LACd2" True
+-SetNetComDataBufferingEnabled "GA3-LACd2" False
+-SetNetComDataBufferSize "GA3-LACd2" 3000
+
+#Acquisition Entity creation and setup for: "GA3-LACd3"
+-CreateCscAcqEnt "GA3-LACd3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA3-LACd3" True
+-SetChannelNumber "GA3-LACd3" 146
+-SetAcqEntReference "GA3-LACd3" 34000004
+-SetInputRange "GA3-LACd3" 3000
+-SetSubSamplingInterleave "GA3-LACd3" 1
+-SetDspLowCutFilterEnabled "GA3-LACd3" True
+-SetDspLowCutFrequency "GA3-LACd3" 0.1
+-SetDspLowCutNumberTaps "GA3-LACd3" 0
+-SetDspHighCutFilterEnabled "GA3-LACd3" True
+-SetDspHighCutFrequency "GA3-LACd3" 8000
+-SetDspHighCutNumberTaps "GA3-LACd3" 256
+-SetInputInverted "GA3-LACd3" True
+-SetNetComDataBufferingEnabled "GA3-LACd3" False
+-SetNetComDataBufferSize "GA3-LACd3" 3000
+
+#Acquisition Entity creation and setup for: "GA3-LACd4"
+-CreateCscAcqEnt "GA3-LACd4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA3-LACd4" True
+-SetChannelNumber "GA3-LACd4" 147
+-SetAcqEntReference "GA3-LACd4" 34000004
+-SetInputRange "GA3-LACd4" 3000
+-SetSubSamplingInterleave "GA3-LACd4" 1
+-SetDspLowCutFilterEnabled "GA3-LACd4" True
+-SetDspLowCutFrequency "GA3-LACd4" 0.1
+-SetDspLowCutNumberTaps "GA3-LACd4" 0
+-SetDspHighCutFilterEnabled "GA3-LACd4" True
+-SetDspHighCutFrequency "GA3-LACd4" 8000
+-SetDspHighCutNumberTaps "GA3-LACd4" 256
+-SetInputInverted "GA3-LACd4" True
+-SetNetComDataBufferingEnabled "GA3-LACd4" False
+-SetNetComDataBufferSize "GA3-LACd4" 3000
+
+#Acquisition Entity creation and setup for: "GA3-LACd5"
+-CreateCscAcqEnt "GA3-LACd5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA3-LACd5" True
+-SetChannelNumber "GA3-LACd5" 148
+-SetAcqEntReference "GA3-LACd5" 34000004
+-SetInputRange "GA3-LACd5" 3000
+-SetSubSamplingInterleave "GA3-LACd5" 1
+-SetDspLowCutFilterEnabled "GA3-LACd5" True
+-SetDspLowCutFrequency "GA3-LACd5" 0.1
+-SetDspLowCutNumberTaps "GA3-LACd5" 0
+-SetDspHighCutFilterEnabled "GA3-LACd5" True
+-SetDspHighCutFrequency "GA3-LACd5" 8000
+-SetDspHighCutNumberTaps "GA3-LACd5" 256
+-SetInputInverted "GA3-LACd5" True
+-SetNetComDataBufferingEnabled "GA3-LACd5" False
+-SetNetComDataBufferSize "GA3-LACd5" 3000
+
+#Acquisition Entity creation and setup for: "GA3-LACd6"
+-CreateCscAcqEnt "GA3-LACd6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA3-LACd6" True
+-SetChannelNumber "GA3-LACd6" 149
+-SetAcqEntReference "GA3-LACd6" 34000004
+-SetInputRange "GA3-LACd6" 3000
+-SetSubSamplingInterleave "GA3-LACd6" 1
+-SetDspLowCutFilterEnabled "GA3-LACd6" True
+-SetDspLowCutFrequency "GA3-LACd6" 0.1
+-SetDspLowCutNumberTaps "GA3-LACd6" 0
+-SetDspHighCutFilterEnabled "GA3-LACd6" True
+-SetDspHighCutFrequency "GA3-LACd6" 8000
+-SetDspHighCutNumberTaps "GA3-LACd6" 256
+-SetInputInverted "GA3-LACd6" True
+-SetNetComDataBufferingEnabled "GA3-LACd6" False
+-SetNetComDataBufferSize "GA3-LACd6" 3000
+
+#Acquisition Entity creation and setup for: "GA3-LACd7"
+-CreateCscAcqEnt "GA3-LACd7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA3-LACd7" True
+-SetChannelNumber "GA3-LACd7" 150
+-SetAcqEntReference "GA3-LACd7" 34000004
+-SetInputRange "GA3-LACd7" 3000
+-SetSubSamplingInterleave "GA3-LACd7" 1
+-SetDspLowCutFilterEnabled "GA3-LACd7" True
+-SetDspLowCutFrequency "GA3-LACd7" 0.1
+-SetDspLowCutNumberTaps "GA3-LACd7" 0
+-SetDspHighCutFilterEnabled "GA3-LACd7" True
+-SetDspHighCutFrequency "GA3-LACd7" 8000
+-SetDspHighCutNumberTaps "GA3-LACd7" 256
+-SetInputInverted "GA3-LACd7" True
+-SetNetComDataBufferingEnabled "GA3-LACd7" False
+-SetNetComDataBufferSize "GA3-LACd7" 3000
+
+#Acquisition Entity creation and setup for: "GA3-LACd8"
+-CreateCscAcqEnt "GA3-LACd8" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GA3-LACd8" True
+-SetChannelNumber "GA3-LACd8" 151
+-SetAcqEntReference "GA3-LACd8" 34000004
+-SetInputRange "GA3-LACd8" 3000
+-SetSubSamplingInterleave "GA3-LACd8" 1
+-SetDspLowCutFilterEnabled "GA3-LACd8" True
+-SetDspLowCutFrequency "GA3-LACd8" 0.1
+-SetDspLowCutNumberTaps "GA3-LACd8" 0
+-SetDspHighCutFilterEnabled "GA3-LACd8" True
+-SetDspHighCutFrequency "GA3-LACd8" 8000
+-SetDspHighCutNumberTaps "GA3-LACd8" 256
+-SetInputInverted "GA3-LACd8" True
+-SetNetComDataBufferingEnabled "GA3-LACd8" False
+-SetNetComDataBufferSize "GA3-LACd8" 3000
+
+#Acquisition Entity creation and setup for: "GB1-RA1"
+-CreateCscAcqEnt "GB1-RA1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB1-RA1" True
+-SetChannelNumber "GB1-RA1" 160
+-SetAcqEntReference "GB1-RA1" 32000005
+-SetInputRange "GB1-RA1" 3000
+-SetSubSamplingInterleave "GB1-RA1" 1
+-SetDspLowCutFilterEnabled "GB1-RA1" True
+-SetDspLowCutFrequency "GB1-RA1" 0.1
+-SetDspLowCutNumberTaps "GB1-RA1" 0
+-SetDspHighCutFilterEnabled "GB1-RA1" True
+-SetDspHighCutFrequency "GB1-RA1" 8000
+-SetDspHighCutNumberTaps "GB1-RA1" 256
+-SetInputInverted "GB1-RA1" True
+-SetNetComDataBufferingEnabled "GB1-RA1" False
+-SetNetComDataBufferSize "GB1-RA1" 3000
+
+#Acquisition Entity creation and setup for: "GB1-RA2"
+-CreateCscAcqEnt "GB1-RA2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB1-RA2" True
+-SetChannelNumber "GB1-RA2" 161
+-SetAcqEntReference "GB1-RA2" 32000005
+-SetInputRange "GB1-RA2" 3000
+-SetSubSamplingInterleave "GB1-RA2" 1
+-SetDspLowCutFilterEnabled "GB1-RA2" True
+-SetDspLowCutFrequency "GB1-RA2" 0.1
+-SetDspLowCutNumberTaps "GB1-RA2" 0
+-SetDspHighCutFilterEnabled "GB1-RA2" True
+-SetDspHighCutFrequency "GB1-RA2" 8000
+-SetDspHighCutNumberTaps "GB1-RA2" 256
+-SetInputInverted "GB1-RA2" True
+-SetNetComDataBufferingEnabled "GB1-RA2" False
+-SetNetComDataBufferSize "GB1-RA2" 3000
+
+#Acquisition Entity creation and setup for: "GB1-RA3"
+-CreateCscAcqEnt "GB1-RA3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB1-RA3" True
+-SetChannelNumber "GB1-RA3" 162
+-SetAcqEntReference "GB1-RA3" 32000005
+-SetInputRange "GB1-RA3" 3000
+-SetSubSamplingInterleave "GB1-RA3" 1
+-SetDspLowCutFilterEnabled "GB1-RA3" True
+-SetDspLowCutFrequency "GB1-RA3" 0.1
+-SetDspLowCutNumberTaps "GB1-RA3" 0
+-SetDspHighCutFilterEnabled "GB1-RA3" True
+-SetDspHighCutFrequency "GB1-RA3" 8000
+-SetDspHighCutNumberTaps "GB1-RA3" 256
+-SetInputInverted "GB1-RA3" True
+-SetNetComDataBufferingEnabled "GB1-RA3" False
+-SetNetComDataBufferSize "GB1-RA3" 3000
+
+#Acquisition Entity creation and setup for: "GB1-RA4"
+-CreateCscAcqEnt "GB1-RA4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB1-RA4" True
+-SetChannelNumber "GB1-RA4" 163
+-SetAcqEntReference "GB1-RA4" 32000005
+-SetInputRange "GB1-RA4" 3000
+-SetSubSamplingInterleave "GB1-RA4" 1
+-SetDspLowCutFilterEnabled "GB1-RA4" True
+-SetDspLowCutFrequency "GB1-RA4" 0.1
+-SetDspLowCutNumberTaps "GB1-RA4" 0
+-SetDspHighCutFilterEnabled "GB1-RA4" True
+-SetDspHighCutFrequency "GB1-RA4" 8000
+-SetDspHighCutNumberTaps "GB1-RA4" 256
+-SetInputInverted "GB1-RA4" True
+-SetNetComDataBufferingEnabled "GB1-RA4" False
+-SetNetComDataBufferSize "GB1-RA4" 3000
+
+#Acquisition Entity creation and setup for: "GB1-RA5"
+-CreateCscAcqEnt "GB1-RA5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB1-RA5" True
+-SetChannelNumber "GB1-RA5" 164
+-SetAcqEntReference "GB1-RA5" 32000005
+-SetInputRange "GB1-RA5" 3000
+-SetSubSamplingInterleave "GB1-RA5" 1
+-SetDspLowCutFilterEnabled "GB1-RA5" True
+-SetDspLowCutFrequency "GB1-RA5" 0.1
+-SetDspLowCutNumberTaps "GB1-RA5" 0
+-SetDspHighCutFilterEnabled "GB1-RA5" True
+-SetDspHighCutFrequency "GB1-RA5" 8000
+-SetDspHighCutNumberTaps "GB1-RA5" 256
+-SetInputInverted "GB1-RA5" True
+-SetNetComDataBufferingEnabled "GB1-RA5" False
+-SetNetComDataBufferSize "GB1-RA5" 3000
+
+#Acquisition Entity creation and setup for: "GB1-RA6"
+-CreateCscAcqEnt "GB1-RA6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB1-RA6" True
+-SetChannelNumber "GB1-RA6" 165
+-SetAcqEntReference "GB1-RA6" 32000005
+-SetInputRange "GB1-RA6" 3000
+-SetSubSamplingInterleave "GB1-RA6" 1
+-SetDspLowCutFilterEnabled "GB1-RA6" True
+-SetDspLowCutFrequency "GB1-RA6" 0.1
+-SetDspLowCutNumberTaps "GB1-RA6" 0
+-SetDspHighCutFilterEnabled "GB1-RA6" True
+-SetDspHighCutFrequency "GB1-RA6" 8000
+-SetDspHighCutNumberTaps "GB1-RA6" 256
+-SetInputInverted "GB1-RA6" True
+-SetNetComDataBufferingEnabled "GB1-RA6" False
+-SetNetComDataBufferSize "GB1-RA6" 3000
+
+#Acquisition Entity creation and setup for: "GB1-RA7"
+-CreateCscAcqEnt "GB1-RA7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB1-RA7" True
+-SetChannelNumber "GB1-RA7" 166
+-SetAcqEntReference "GB1-RA7" 32000005
+-SetInputRange "GB1-RA7" 3000
+-SetSubSamplingInterleave "GB1-RA7" 1
+-SetDspLowCutFilterEnabled "GB1-RA7" True
+-SetDspLowCutFrequency "GB1-RA7" 0.1
+-SetDspLowCutNumberTaps "GB1-RA7" 0
+-SetDspHighCutFilterEnabled "GB1-RA7" True
+-SetDspHighCutFrequency "GB1-RA7" 8000
+-SetDspHighCutNumberTaps "GB1-RA7" 256
+-SetInputInverted "GB1-RA7" True
+-SetNetComDataBufferingEnabled "GB1-RA7" False
+-SetNetComDataBufferSize "GB1-RA7" 3000
+
+#Acquisition Entity creation and setup for: "GB1-RA8"
+-CreateCscAcqEnt "GB1-RA8" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB1-RA8" True
+-SetChannelNumber "GB1-RA8" 167
+-SetAcqEntReference "GB1-RA8" 32000005
+-SetInputRange "GB1-RA8" 3000
+-SetSubSamplingInterleave "GB1-RA8" 1
+-SetDspLowCutFilterEnabled "GB1-RA8" True
+-SetDspLowCutFrequency "GB1-RA8" 0.1
+-SetDspLowCutNumberTaps "GB1-RA8" 0
+-SetDspHighCutFilterEnabled "GB1-RA8" True
+-SetDspHighCutFrequency "GB1-RA8" 8000
+-SetDspHighCutNumberTaps "GB1-RA8" 256
+-SetInputInverted "GB1-RA8" True
+-SetNetComDataBufferingEnabled "GB1-RA8" False
+-SetNetComDataBufferSize "GB1-RA8" 3000
+
+#Acquisition Entity creation and setup for: "GB2-LAC1"
+-CreateCscAcqEnt "GB2-LAC1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB2-LAC1" True
+-SetChannelNumber "GB2-LAC1" 168
+-SetAcqEntReference "GB2-LAC1" 33000005
+-SetInputRange "GB2-LAC1" 3000
+-SetSubSamplingInterleave "GB2-LAC1" 1
+-SetDspLowCutFilterEnabled "GB2-LAC1" True
+-SetDspLowCutFrequency "GB2-LAC1" 0.1
+-SetDspLowCutNumberTaps "GB2-LAC1" 0
+-SetDspHighCutFilterEnabled "GB2-LAC1" True
+-SetDspHighCutFrequency "GB2-LAC1" 8000
+-SetDspHighCutNumberTaps "GB2-LAC1" 256
+-SetInputInverted "GB2-LAC1" True
+-SetNetComDataBufferingEnabled "GB2-LAC1" False
+-SetNetComDataBufferSize "GB2-LAC1" 3000
+
+#Acquisition Entity creation and setup for: "GB2-LAC2"
+-CreateCscAcqEnt "GB2-LAC2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB2-LAC2" True
+-SetChannelNumber "GB2-LAC2" 169
+-SetAcqEntReference "GB2-LAC2" 33000005
+-SetInputRange "GB2-LAC2" 3000
+-SetSubSamplingInterleave "GB2-LAC2" 1
+-SetDspLowCutFilterEnabled "GB2-LAC2" True
+-SetDspLowCutFrequency "GB2-LAC2" 0.1
+-SetDspLowCutNumberTaps "GB2-LAC2" 0
+-SetDspHighCutFilterEnabled "GB2-LAC2" True
+-SetDspHighCutFrequency "GB2-LAC2" 8000
+-SetDspHighCutNumberTaps "GB2-LAC2" 256
+-SetInputInverted "GB2-LAC2" True
+-SetNetComDataBufferingEnabled "GB2-LAC2" False
+-SetNetComDataBufferSize "GB2-LAC2" 3000
+
+#Acquisition Entity creation and setup for: "GB2-LAC3"
+-CreateCscAcqEnt "GB2-LAC3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB2-LAC3" True
+-SetChannelNumber "GB2-LAC3" 170
+-SetAcqEntReference "GB2-LAC3" 33000005
+-SetInputRange "GB2-LAC3" 3000
+-SetSubSamplingInterleave "GB2-LAC3" 1
+-SetDspLowCutFilterEnabled "GB2-LAC3" True
+-SetDspLowCutFrequency "GB2-LAC3" 0.1
+-SetDspLowCutNumberTaps "GB2-LAC3" 0
+-SetDspHighCutFilterEnabled "GB2-LAC3" True
+-SetDspHighCutFrequency "GB2-LAC3" 8000
+-SetDspHighCutNumberTaps "GB2-LAC3" 256
+-SetInputInverted "GB2-LAC3" True
+-SetNetComDataBufferingEnabled "GB2-LAC3" False
+-SetNetComDataBufferSize "GB2-LAC3" 3000
+
+#Acquisition Entity creation and setup for: "GB2-LAC4"
+-CreateCscAcqEnt "GB2-LAC4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB2-LAC4" True
+-SetChannelNumber "GB2-LAC4" 171
+-SetAcqEntReference "GB2-LAC4" 33000005
+-SetInputRange "GB2-LAC4" 3000
+-SetSubSamplingInterleave "GB2-LAC4" 1
+-SetDspLowCutFilterEnabled "GB2-LAC4" True
+-SetDspLowCutFrequency "GB2-LAC4" 0.1
+-SetDspLowCutNumberTaps "GB2-LAC4" 0
+-SetDspHighCutFilterEnabled "GB2-LAC4" True
+-SetDspHighCutFrequency "GB2-LAC4" 8000
+-SetDspHighCutNumberTaps "GB2-LAC4" 256
+-SetInputInverted "GB2-LAC4" True
+-SetNetComDataBufferingEnabled "GB2-LAC4" False
+-SetNetComDataBufferSize "GB2-LAC4" 3000
+
+#Acquisition Entity creation and setup for: "GB2-LAC5"
+-CreateCscAcqEnt "GB2-LAC5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB2-LAC5" True
+-SetChannelNumber "GB2-LAC5" 172
+-SetAcqEntReference "GB2-LAC5" 33000005
+-SetInputRange "GB2-LAC5" 3000
+-SetSubSamplingInterleave "GB2-LAC5" 1
+-SetDspLowCutFilterEnabled "GB2-LAC5" True
+-SetDspLowCutFrequency "GB2-LAC5" 0.1
+-SetDspLowCutNumberTaps "GB2-LAC5" 0
+-SetDspHighCutFilterEnabled "GB2-LAC5" True
+-SetDspHighCutFrequency "GB2-LAC5" 8000
+-SetDspHighCutNumberTaps "GB2-LAC5" 256
+-SetInputInverted "GB2-LAC5" True
+-SetNetComDataBufferingEnabled "GB2-LAC5" False
+-SetNetComDataBufferSize "GB2-LAC5" 3000
+
+#Acquisition Entity creation and setup for: "GB2-LAC6"
+-CreateCscAcqEnt "GB2-LAC6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB2-LAC6" True
+-SetChannelNumber "GB2-LAC6" 173
+-SetAcqEntReference "GB2-LAC6" 33000005
+-SetInputRange "GB2-LAC6" 3000
+-SetSubSamplingInterleave "GB2-LAC6" 1
+-SetDspLowCutFilterEnabled "GB2-LAC6" True
+-SetDspLowCutFrequency "GB2-LAC6" 0.1
+-SetDspLowCutNumberTaps "GB2-LAC6" 0
+-SetDspHighCutFilterEnabled "GB2-LAC6" True
+-SetDspHighCutFrequency "GB2-LAC6" 8000
+-SetDspHighCutNumberTaps "GB2-LAC6" 256
+-SetInputInverted "GB2-LAC6" True
+-SetNetComDataBufferingEnabled "GB2-LAC6" False
+-SetNetComDataBufferSize "GB2-LAC6" 3000
+
+#Acquisition Entity creation and setup for: "GB2-LAC7"
+-CreateCscAcqEnt "GB2-LAC7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB2-LAC7" True
+-SetChannelNumber "GB2-LAC7" 174
+-SetAcqEntReference "GB2-LAC7" 33000005
+-SetInputRange "GB2-LAC7" 3000
+-SetSubSamplingInterleave "GB2-LAC7" 1
+-SetDspLowCutFilterEnabled "GB2-LAC7" True
+-SetDspLowCutFrequency "GB2-LAC7" 0.1
+-SetDspLowCutNumberTaps "GB2-LAC7" 0
+-SetDspHighCutFilterEnabled "GB2-LAC7" True
+-SetDspHighCutFrequency "GB2-LAC7" 8000
+-SetDspHighCutNumberTaps "GB2-LAC7" 256
+-SetInputInverted "GB2-LAC7" True
+-SetNetComDataBufferingEnabled "GB2-LAC7" False
+-SetNetComDataBufferSize "GB2-LAC7" 3000
+
+#Acquisition Entity creation and setup for: "GB2-LAC8"
+-CreateCscAcqEnt "GB2-LAC8" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GB2-LAC8" True
+-SetChannelNumber "GB2-LAC8" 175
+-SetAcqEntReference "GB2-LAC8" 33000005
+-SetInputRange "GB2-LAC8" 3000
+-SetSubSamplingInterleave "GB2-LAC8" 1
+-SetDspLowCutFilterEnabled "GB2-LAC8" True
+-SetDspLowCutFrequency "GB2-LAC8" 0.1
+-SetDspLowCutNumberTaps "GB2-LAC8" 0
+-SetDspHighCutFilterEnabled "GB2-LAC8" True
+-SetDspHighCutFrequency "GB2-LAC8" 8000
+-SetDspHighCutNumberTaps "GB2-LAC8" 256
+-SetInputInverted "GB2-LAC8" True
+-SetNetComDataBufferingEnabled "GB2-LAC8" False
+-SetNetComDataBufferSize "GB2-LAC8" 3000
+
+#Acquisition Entity creation and setup for: "GC1-LMC1"
+-CreateCscAcqEnt "GC1-LMC1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC1-LMC1" True
+-SetChannelNumber "GC1-LMC1" 192
+-SetAcqEntReference "GC1-LMC1" 32000006
+-SetInputRange "GC1-LMC1" 3000
+-SetSubSamplingInterleave "GC1-LMC1" 1
+-SetDspLowCutFilterEnabled "GC1-LMC1" True
+-SetDspLowCutFrequency "GC1-LMC1" 0.1
+-SetDspLowCutNumberTaps "GC1-LMC1" 0
+-SetDspHighCutFilterEnabled "GC1-LMC1" True
+-SetDspHighCutFrequency "GC1-LMC1" 8000
+-SetDspHighCutNumberTaps "GC1-LMC1" 256
+-SetInputInverted "GC1-LMC1" True
+-SetNetComDataBufferingEnabled "GC1-LMC1" False
+-SetNetComDataBufferSize "GC1-LMC1" 3000
+
+#Acquisition Entity creation and setup for: "GC1-LMC2"
+-CreateCscAcqEnt "GC1-LMC2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC1-LMC2" True
+-SetChannelNumber "GC1-LMC2" 193
+-SetAcqEntReference "GC1-LMC2" 32000006
+-SetInputRange "GC1-LMC2" 3000
+-SetSubSamplingInterleave "GC1-LMC2" 1
+-SetDspLowCutFilterEnabled "GC1-LMC2" True
+-SetDspLowCutFrequency "GC1-LMC2" 0.1
+-SetDspLowCutNumberTaps "GC1-LMC2" 0
+-SetDspHighCutFilterEnabled "GC1-LMC2" True
+-SetDspHighCutFrequency "GC1-LMC2" 8000
+-SetDspHighCutNumberTaps "GC1-LMC2" 256
+-SetInputInverted "GC1-LMC2" True
+-SetNetComDataBufferingEnabled "GC1-LMC2" False
+-SetNetComDataBufferSize "GC1-LMC2" 3000
+
+#Acquisition Entity creation and setup for: "GC1-LMC3"
+-CreateCscAcqEnt "GC1-LMC3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC1-LMC3" True
+-SetChannelNumber "GC1-LMC3" 194
+-SetAcqEntReference "GC1-LMC3" 32000006
+-SetInputRange "GC1-LMC3" 3000
+-SetSubSamplingInterleave "GC1-LMC3" 1
+-SetDspLowCutFilterEnabled "GC1-LMC3" True
+-SetDspLowCutFrequency "GC1-LMC3" 0.1
+-SetDspLowCutNumberTaps "GC1-LMC3" 0
+-SetDspHighCutFilterEnabled "GC1-LMC3" True
+-SetDspHighCutFrequency "GC1-LMC3" 8000
+-SetDspHighCutNumberTaps "GC1-LMC3" 256
+-SetInputInverted "GC1-LMC3" True
+-SetNetComDataBufferingEnabled "GC1-LMC3" False
+-SetNetComDataBufferSize "GC1-LMC3" 3000
+
+#Acquisition Entity creation and setup for: "GC1-LMC4"
+-CreateCscAcqEnt "GC1-LMC4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC1-LMC4" True
+-SetChannelNumber "GC1-LMC4" 195
+-SetAcqEntReference "GC1-LMC4" 32000006
+-SetInputRange "GC1-LMC4" 3000
+-SetSubSamplingInterleave "GC1-LMC4" 1
+-SetDspLowCutFilterEnabled "GC1-LMC4" True
+-SetDspLowCutFrequency "GC1-LMC4" 0.1
+-SetDspLowCutNumberTaps "GC1-LMC4" 0
+-SetDspHighCutFilterEnabled "GC1-LMC4" True
+-SetDspHighCutFrequency "GC1-LMC4" 8000
+-SetDspHighCutNumberTaps "GC1-LMC4" 256
+-SetInputInverted "GC1-LMC4" True
+-SetNetComDataBufferingEnabled "GC1-LMC4" False
+-SetNetComDataBufferSize "GC1-LMC4" 3000
+
+#Acquisition Entity creation and setup for: "GC1-LMC5"
+-CreateCscAcqEnt "GC1-LMC5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC1-LMC5" True
+-SetChannelNumber "GC1-LMC5" 196
+-SetAcqEntReference "GC1-LMC5" 32000006
+-SetInputRange "GC1-LMC5" 3000
+-SetSubSamplingInterleave "GC1-LMC5" 1
+-SetDspLowCutFilterEnabled "GC1-LMC5" True
+-SetDspLowCutFrequency "GC1-LMC5" 0.1
+-SetDspLowCutNumberTaps "GC1-LMC5" 0
+-SetDspHighCutFilterEnabled "GC1-LMC5" True
+-SetDspHighCutFrequency "GC1-LMC5" 8000
+-SetDspHighCutNumberTaps "GC1-LMC5" 256
+-SetInputInverted "GC1-LMC5" True
+-SetNetComDataBufferingEnabled "GC1-LMC5" False
+-SetNetComDataBufferSize "GC1-LMC5" 3000
+
+#Acquisition Entity creation and setup for: "GC1-LMC6"
+-CreateCscAcqEnt "GC1-LMC6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC1-LMC6" True
+-SetChannelNumber "GC1-LMC6" 197
+-SetAcqEntReference "GC1-LMC6" 32000006
+-SetInputRange "GC1-LMC6" 3000
+-SetSubSamplingInterleave "GC1-LMC6" 1
+-SetDspLowCutFilterEnabled "GC1-LMC6" True
+-SetDspLowCutFrequency "GC1-LMC6" 0.1
+-SetDspLowCutNumberTaps "GC1-LMC6" 0
+-SetDspHighCutFilterEnabled "GC1-LMC6" True
+-SetDspHighCutFrequency "GC1-LMC6" 8000
+-SetDspHighCutNumberTaps "GC1-LMC6" 256
+-SetInputInverted "GC1-LMC6" True
+-SetNetComDataBufferingEnabled "GC1-LMC6" False
+-SetNetComDataBufferSize "GC1-LMC6" 3000
+
+#Acquisition Entity creation and setup for: "GC1-LMC7"
+-CreateCscAcqEnt "GC1-LMC7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC1-LMC7" True
+-SetChannelNumber "GC1-LMC7" 198
+-SetAcqEntReference "GC1-LMC7" 32000006
+-SetInputRange "GC1-LMC7" 3000
+-SetSubSamplingInterleave "GC1-LMC7" 1
+-SetDspLowCutFilterEnabled "GC1-LMC7" True
+-SetDspLowCutFrequency "GC1-LMC7" 0.1
+-SetDspLowCutNumberTaps "GC1-LMC7" 0
+-SetDspHighCutFilterEnabled "GC1-LMC7" True
+-SetDspHighCutFrequency "GC1-LMC7" 8000
+-SetDspHighCutNumberTaps "GC1-LMC7" 256
+-SetInputInverted "GC1-LMC7" True
+-SetNetComDataBufferingEnabled "GC1-LMC7" False
+-SetNetComDataBufferSize "GC1-LMC7" 3000
+
+#Acquisition Entity creation and setup for: "GC1-LMC8"
+-CreateCscAcqEnt "GC1-LMC8" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC1-LMC8" True
+-SetChannelNumber "GC1-LMC8" 199
+-SetAcqEntReference "GC1-LMC8" 32000006
+-SetInputRange "GC1-LMC8" 3000
+-SetSubSamplingInterleave "GC1-LMC8" 1
+-SetDspLowCutFilterEnabled "GC1-LMC8" True
+-SetDspLowCutFrequency "GC1-LMC8" 0.1
+-SetDspLowCutNumberTaps "GC1-LMC8" 0
+-SetDspHighCutFilterEnabled "GC1-LMC8" True
+-SetDspHighCutFrequency "GC1-LMC8" 8000
+-SetDspHighCutNumberTaps "GC1-LMC8" 256
+-SetInputInverted "GC1-LMC8" True
+-SetNetComDataBufferingEnabled "GC1-LMC8" False
+-SetNetComDataBufferSize "GC1-LMC8" 3000
+
+#Acquisition Entity creation and setup for: "GC2-LOF1"
+-CreateCscAcqEnt "GC2-LOF1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC2-LOF1" True
+-SetChannelNumber "GC2-LOF1" 200
+-SetAcqEntReference "GC2-LOF1" 33000006
+-SetInputRange "GC2-LOF1" 3000
+-SetSubSamplingInterleave "GC2-LOF1" 1
+-SetDspLowCutFilterEnabled "GC2-LOF1" True
+-SetDspLowCutFrequency "GC2-LOF1" 0.1
+-SetDspLowCutNumberTaps "GC2-LOF1" 0
+-SetDspHighCutFilterEnabled "GC2-LOF1" True
+-SetDspHighCutFrequency "GC2-LOF1" 8000
+-SetDspHighCutNumberTaps "GC2-LOF1" 256
+-SetInputInverted "GC2-LOF1" True
+-SetNetComDataBufferingEnabled "GC2-LOF1" False
+-SetNetComDataBufferSize "GC2-LOF1" 3000
+
+#Acquisition Entity creation and setup for: "GC2-LOF2"
+-CreateCscAcqEnt "GC2-LOF2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC2-LOF2" True
+-SetChannelNumber "GC2-LOF2" 201
+-SetAcqEntReference "GC2-LOF2" 33000006
+-SetInputRange "GC2-LOF2" 3000
+-SetSubSamplingInterleave "GC2-LOF2" 1
+-SetDspLowCutFilterEnabled "GC2-LOF2" True
+-SetDspLowCutFrequency "GC2-LOF2" 0.1
+-SetDspLowCutNumberTaps "GC2-LOF2" 0
+-SetDspHighCutFilterEnabled "GC2-LOF2" True
+-SetDspHighCutFrequency "GC2-LOF2" 8000
+-SetDspHighCutNumberTaps "GC2-LOF2" 256
+-SetInputInverted "GC2-LOF2" True
+-SetNetComDataBufferingEnabled "GC2-LOF2" False
+-SetNetComDataBufferSize "GC2-LOF2" 3000
+
+#Acquisition Entity creation and setup for: "GC2-LOF3"
+-CreateCscAcqEnt "GC2-LOF3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC2-LOF3" True
+-SetChannelNumber "GC2-LOF3" 202
+-SetAcqEntReference "GC2-LOF3" 33000006
+-SetInputRange "GC2-LOF3" 3000
+-SetSubSamplingInterleave "GC2-LOF3" 1
+-SetDspLowCutFilterEnabled "GC2-LOF3" True
+-SetDspLowCutFrequency "GC2-LOF3" 0.1
+-SetDspLowCutNumberTaps "GC2-LOF3" 0
+-SetDspHighCutFilterEnabled "GC2-LOF3" True
+-SetDspHighCutFrequency "GC2-LOF3" 8000
+-SetDspHighCutNumberTaps "GC2-LOF3" 256
+-SetInputInverted "GC2-LOF3" True
+-SetNetComDataBufferingEnabled "GC2-LOF3" False
+-SetNetComDataBufferSize "GC2-LOF3" 3000
+
+#Acquisition Entity creation and setup for: "GC2-LOF4"
+-CreateCscAcqEnt "GC2-LOF4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC2-LOF4" True
+-SetChannelNumber "GC2-LOF4" 203
+-SetAcqEntReference "GC2-LOF4" 33000006
+-SetInputRange "GC2-LOF4" 3000
+-SetSubSamplingInterleave "GC2-LOF4" 1
+-SetDspLowCutFilterEnabled "GC2-LOF4" True
+-SetDspLowCutFrequency "GC2-LOF4" 0.1
+-SetDspLowCutNumberTaps "GC2-LOF4" 0
+-SetDspHighCutFilterEnabled "GC2-LOF4" True
+-SetDspHighCutFrequency "GC2-LOF4" 8000
+-SetDspHighCutNumberTaps "GC2-LOF4" 256
+-SetInputInverted "GC2-LOF4" True
+-SetNetComDataBufferingEnabled "GC2-LOF4" False
+-SetNetComDataBufferSize "GC2-LOF4" 3000
+
+#Acquisition Entity creation and setup for: "GC2-LOF5"
+-CreateCscAcqEnt "GC2-LOF5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC2-LOF5" True
+-SetChannelNumber "GC2-LOF5" 204
+-SetAcqEntReference "GC2-LOF5" 33000006
+-SetInputRange "GC2-LOF5" 3000
+-SetSubSamplingInterleave "GC2-LOF5" 1
+-SetDspLowCutFilterEnabled "GC2-LOF5" True
+-SetDspLowCutFrequency "GC2-LOF5" 0.1
+-SetDspLowCutNumberTaps "GC2-LOF5" 0
+-SetDspHighCutFilterEnabled "GC2-LOF5" True
+-SetDspHighCutFrequency "GC2-LOF5" 8000
+-SetDspHighCutNumberTaps "GC2-LOF5" 256
+-SetInputInverted "GC2-LOF5" True
+-SetNetComDataBufferingEnabled "GC2-LOF5" False
+-SetNetComDataBufferSize "GC2-LOF5" 3000
+
+#Acquisition Entity creation and setup for: "GC2-LOF6"
+-CreateCscAcqEnt "GC2-LOF6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC2-LOF6" True
+-SetChannelNumber "GC2-LOF6" 205
+-SetAcqEntReference "GC2-LOF6" 33000006
+-SetInputRange "GC2-LOF6" 3000
+-SetSubSamplingInterleave "GC2-LOF6" 1
+-SetDspLowCutFilterEnabled "GC2-LOF6" True
+-SetDspLowCutFrequency "GC2-LOF6" 0.1
+-SetDspLowCutNumberTaps "GC2-LOF6" 0
+-SetDspHighCutFilterEnabled "GC2-LOF6" True
+-SetDspHighCutFrequency "GC2-LOF6" 8000
+-SetDspHighCutNumberTaps "GC2-LOF6" 256
+-SetInputInverted "GC2-LOF6" True
+-SetNetComDataBufferingEnabled "GC2-LOF6" False
+-SetNetComDataBufferSize "GC2-LOF6" 3000
+
+#Acquisition Entity creation and setup for: "GC2-LOF7"
+-CreateCscAcqEnt "GC2-LOF7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC2-LOF7" True
+-SetChannelNumber "GC2-LOF7" 206
+-SetAcqEntReference "GC2-LOF7" 33000006
+-SetInputRange "GC2-LOF7" 3000
+-SetSubSamplingInterleave "GC2-LOF7" 1
+-SetDspLowCutFilterEnabled "GC2-LOF7" True
+-SetDspLowCutFrequency "GC2-LOF7" 0.1
+-SetDspLowCutNumberTaps "GC2-LOF7" 0
+-SetDspHighCutFilterEnabled "GC2-LOF7" True
+-SetDspHighCutFrequency "GC2-LOF7" 8000
+-SetDspHighCutNumberTaps "GC2-LOF7" 256
+-SetInputInverted "GC2-LOF7" True
+-SetNetComDataBufferingEnabled "GC2-LOF7" False
+-SetNetComDataBufferSize "GC2-LOF7" 3000
+
+#Acquisition Entity creation and setup for: "GC2-LOF8"
+-CreateCscAcqEnt "GC2-LOF8" "AcqSystem1"
+-SetAcqEntProcessingEnabled "GC2-LOF8" True
+-SetChannelNumber "GC2-LOF8" 207
+-SetAcqEntReference "GC2-LOF8" 33000006
+-SetInputRange "GC2-LOF8" 3000
+-SetSubSamplingInterleave "GC2-LOF8" 1
+-SetDspLowCutFilterEnabled "GC2-LOF8" True
+-SetDspLowCutFrequency "GC2-LOF8" 0.1
+-SetDspLowCutNumberTaps "GC2-LOF8" 0
+-SetDspHighCutFilterEnabled "GC2-LOF8" True
+-SetDspHighCutFrequency "GC2-LOF8" 8000
+-SetDspHighCutNumberTaps "GC2-LOF8" 256
+-SetInputInverted "GC2-LOF8" True
+-SetNetComDataBufferingEnabled "GC2-LOF8" False
+-SetNetComDataBufferSize "GC2-LOF8" 3000
+
+#Acquisition Entity creation and setup for: "LA1"
+-CreateCscAcqEnt "LA1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA1" True
+-SetChannelNumber "LA1" 0
+-SetAcqEntReference "LA1" 32000000
+-SetInputRange "LA1" 3000
+-SetSubSamplingInterleave "LA1" 16
+-SetDspLowCutFilterEnabled "LA1" True
+-SetDspLowCutFrequency "LA1" 0.1
+-SetDspLowCutNumberTaps "LA1" 0
+-SetDspHighCutFilterEnabled "LA1" True
+-SetDspHighCutFrequency "LA1" 500
+-SetDspHighCutNumberTaps "LA1" 256
+-SetInputInverted "LA1" True
+-SetNetComDataBufferingEnabled "LA1" False
+-SetNetComDataBufferSize "LA1" 3000
+
+#Acquisition Entity creation and setup for: "LA2"
+-CreateCscAcqEnt "LA2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA2" True
+-SetChannelNumber "LA2" 1
+-SetAcqEntReference "LA2" 32000000
+-SetInputRange "LA2" 3000
+-SetSubSamplingInterleave "LA2" 16
+-SetDspLowCutFilterEnabled "LA2" True
+-SetDspLowCutFrequency "LA2" 0.1
+-SetDspLowCutNumberTaps "LA2" 0
+-SetDspHighCutFilterEnabled "LA2" True
+-SetDspHighCutFrequency "LA2" 500
+-SetDspHighCutNumberTaps "LA2" 256
+-SetInputInverted "LA2" True
+-SetNetComDataBufferingEnabled "LA2" False
+-SetNetComDataBufferSize "LA2" 3000
+
+#Acquisition Entity creation and setup for: "LA3"
+-CreateCscAcqEnt "LA3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA3" True
+-SetChannelNumber "LA3" 2
+-SetAcqEntReference "LA3" 32000000
+-SetInputRange "LA3" 3000
+-SetSubSamplingInterleave "LA3" 16
+-SetDspLowCutFilterEnabled "LA3" True
+-SetDspLowCutFrequency "LA3" 0.1
+-SetDspLowCutNumberTaps "LA3" 0
+-SetDspHighCutFilterEnabled "LA3" True
+-SetDspHighCutFrequency "LA3" 500
+-SetDspHighCutNumberTaps "LA3" 256
+-SetInputInverted "LA3" True
+-SetNetComDataBufferingEnabled "LA3" False
+-SetNetComDataBufferSize "LA3" 3000
+
+#Acquisition Entity creation and setup for: "LA4"
+-CreateCscAcqEnt "LA4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA4" True
+-SetChannelNumber "LA4" 3
+-SetAcqEntReference "LA4" 32000000
+-SetInputRange "LA4" 3000
+-SetSubSamplingInterleave "LA4" 16
+-SetDspLowCutFilterEnabled "LA4" True
+-SetDspLowCutFrequency "LA4" 0.1
+-SetDspLowCutNumberTaps "LA4" 0
+-SetDspHighCutFilterEnabled "LA4" True
+-SetDspHighCutFrequency "LA4" 500
+-SetDspHighCutNumberTaps "LA4" 256
+-SetInputInverted "LA4" True
+-SetNetComDataBufferingEnabled "LA4" False
+-SetNetComDataBufferSize "LA4" 3000
+
+#Acquisition Entity creation and setup for: "LA5"
+-CreateCscAcqEnt "LA5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA5" True
+-SetChannelNumber "LA5" 4
+-SetAcqEntReference "LA5" 32000000
+-SetInputRange "LA5" 3000
+-SetSubSamplingInterleave "LA5" 16
+-SetDspLowCutFilterEnabled "LA5" True
+-SetDspLowCutFrequency "LA5" 0.1
+-SetDspLowCutNumberTaps "LA5" 0
+-SetDspHighCutFilterEnabled "LA5" True
+-SetDspHighCutFrequency "LA5" 500
+-SetDspHighCutNumberTaps "LA5" 256
+-SetInputInverted "LA5" True
+-SetNetComDataBufferingEnabled "LA5" False
+-SetNetComDataBufferSize "LA5" 3000
+
+#Acquisition Entity creation and setup for: "LA6"
+-CreateCscAcqEnt "LA6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA6" True
+-SetChannelNumber "LA6" 5
+-SetAcqEntReference "LA6" 32000000
+-SetInputRange "LA6" 3000
+-SetSubSamplingInterleave "LA6" 16
+-SetDspLowCutFilterEnabled "LA6" True
+-SetDspLowCutFrequency "LA6" 0.1
+-SetDspLowCutNumberTaps "LA6" 0
+-SetDspHighCutFilterEnabled "LA6" True
+-SetDspHighCutFrequency "LA6" 500
+-SetDspHighCutNumberTaps "LA6" 256
+-SetInputInverted "LA6" True
+-SetNetComDataBufferingEnabled "LA6" False
+-SetNetComDataBufferSize "LA6" 3000
+
+#Acquisition Entity creation and setup for: "LA7"
+-CreateCscAcqEnt "LA7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA7" True
+-SetChannelNumber "LA7" 6
+-SetAcqEntReference "LA7" 32000000
+-SetInputRange "LA7" 3000
+-SetSubSamplingInterleave "LA7" 16
+-SetDspLowCutFilterEnabled "LA7" True
+-SetDspLowCutFrequency "LA7" 0.1
+-SetDspLowCutNumberTaps "LA7" 0
+-SetDspHighCutFilterEnabled "LA7" True
+-SetDspHighCutFrequency "LA7" 500
+-SetDspHighCutNumberTaps "LA7" 256
+-SetInputInverted "LA7" True
+-SetNetComDataBufferingEnabled "LA7" False
+-SetNetComDataBufferSize "LA7" 3000
+
+#Acquisition Entity creation and setup for: "RA1"
+-CreateCscAcqEnt "RA1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA1" True
+-SetChannelNumber "RA1" 7
+-SetAcqEntReference "RA1" 32000000
+-SetInputRange "RA1" 3000
+-SetSubSamplingInterleave "RA1" 16
+-SetDspLowCutFilterEnabled "RA1" True
+-SetDspLowCutFrequency "RA1" 0.1
+-SetDspLowCutNumberTaps "RA1" 0
+-SetDspHighCutFilterEnabled "RA1" True
+-SetDspHighCutFrequency "RA1" 500
+-SetDspHighCutNumberTaps "RA1" 256
+-SetInputInverted "RA1" True
+-SetNetComDataBufferingEnabled "RA1" False
+-SetNetComDataBufferSize "RA1" 3000
+
+#Acquisition Entity creation and setup for: "RA2"
+-CreateCscAcqEnt "RA2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA2" True
+-SetChannelNumber "RA2" 8
+-SetAcqEntReference "RA2" 32000000
+-SetInputRange "RA2" 3000
+-SetSubSamplingInterleave "RA2" 16
+-SetDspLowCutFilterEnabled "RA2" True
+-SetDspLowCutFrequency "RA2" 0.1
+-SetDspLowCutNumberTaps "RA2" 0
+-SetDspHighCutFilterEnabled "RA2" True
+-SetDspHighCutFrequency "RA2" 500
+-SetDspHighCutNumberTaps "RA2" 256
+-SetInputInverted "RA2" True
+-SetNetComDataBufferingEnabled "RA2" False
+-SetNetComDataBufferSize "RA2" 3000
+
+#Acquisition Entity creation and setup for: "RA3"
+-CreateCscAcqEnt "RA3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA3" True
+-SetChannelNumber "RA3" 9
+-SetAcqEntReference "RA3" 32000000
+-SetInputRange "RA3" 3000
+-SetSubSamplingInterleave "RA3" 16
+-SetDspLowCutFilterEnabled "RA3" True
+-SetDspLowCutFrequency "RA3" 0.1
+-SetDspLowCutNumberTaps "RA3" 0
+-SetDspHighCutFilterEnabled "RA3" True
+-SetDspHighCutFrequency "RA3" 500
+-SetDspHighCutNumberTaps "RA3" 256
+-SetInputInverted "RA3" True
+-SetNetComDataBufferingEnabled "RA3" False
+-SetNetComDataBufferSize "RA3" 3000
+
+#Acquisition Entity creation and setup for: "RA4"
+-CreateCscAcqEnt "RA4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA4" True
+-SetChannelNumber "RA4" 10
+-SetAcqEntReference "RA4" 32000000
+-SetInputRange "RA4" 3000
+-SetSubSamplingInterleave "RA4" 16
+-SetDspLowCutFilterEnabled "RA4" True
+-SetDspLowCutFrequency "RA4" 0.1
+-SetDspLowCutNumberTaps "RA4" 0
+-SetDspHighCutFilterEnabled "RA4" True
+-SetDspHighCutFrequency "RA4" 500
+-SetDspHighCutNumberTaps "RA4" 256
+-SetInputInverted "RA4" True
+-SetNetComDataBufferingEnabled "RA4" False
+-SetNetComDataBufferSize "RA4" 3000
+
+#Acquisition Entity creation and setup for: "RA5"
+-CreateCscAcqEnt "RA5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA5" True
+-SetChannelNumber "RA5" 11
+-SetAcqEntReference "RA5" 32000000
+-SetInputRange "RA5" 3000
+-SetSubSamplingInterleave "RA5" 16
+-SetDspLowCutFilterEnabled "RA5" True
+-SetDspLowCutFrequency "RA5" 0.1
+-SetDspLowCutNumberTaps "RA5" 0
+-SetDspHighCutFilterEnabled "RA5" True
+-SetDspHighCutFrequency "RA5" 500
+-SetDspHighCutNumberTaps "RA5" 256
+-SetInputInverted "RA5" True
+-SetNetComDataBufferingEnabled "RA5" False
+-SetNetComDataBufferSize "RA5" 3000
+
+#Acquisition Entity creation and setup for: "RA6"
+-CreateCscAcqEnt "RA6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA6" True
+-SetChannelNumber "RA6" 12
+-SetAcqEntReference "RA6" 32000000
+-SetInputRange "RA6" 3000
+-SetSubSamplingInterleave "RA6" 16
+-SetDspLowCutFilterEnabled "RA6" True
+-SetDspLowCutFrequency "RA6" 0.1
+-SetDspLowCutNumberTaps "RA6" 0
+-SetDspHighCutFilterEnabled "RA6" True
+-SetDspHighCutFrequency "RA6" 500
+-SetDspHighCutNumberTaps "RA6" 256
+-SetInputInverted "RA6" True
+-SetNetComDataBufferingEnabled "RA6" False
+-SetNetComDataBufferSize "RA6" 3000
+
+#Acquisition Entity creation and setup for: "RA7"
+-CreateCscAcqEnt "RA7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA7" True
+-SetChannelNumber "RA7" 13
+-SetAcqEntReference "RA7" 32000000
+-SetInputRange "RA7" 3000
+-SetSubSamplingInterleave "RA7" 16
+-SetDspLowCutFilterEnabled "RA7" True
+-SetDspLowCutFrequency "RA7" 0.1
+-SetDspLowCutNumberTaps "RA7" 0
+-SetDspHighCutFilterEnabled "RA7" True
+-SetDspHighCutFrequency "RA7" 500
+-SetDspHighCutNumberTaps "RA7" 256
+-SetInputInverted "RA7" True
+-SetNetComDataBufferingEnabled "RA7" False
+-SetNetComDataBufferSize "RA7" 3000
+
+#Acquisition Entity creation and setup for: "RA8"
+-CreateCscAcqEnt "RA8" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA8" True
+-SetChannelNumber "RA8" 14
+-SetAcqEntReference "RA8" 32000000
+-SetInputRange "RA8" 3000
+-SetSubSamplingInterleave "RA8" 16
+-SetDspLowCutFilterEnabled "RA8" True
+-SetDspLowCutFrequency "RA8" 0.1
+-SetDspLowCutNumberTaps "RA8" 0
+-SetDspHighCutFilterEnabled "RA8" True
+-SetDspHighCutFrequency "RA8" 500
+-SetDspHighCutNumberTaps "RA8" 256
+-SetInputInverted "RA8" True
+-SetNetComDataBufferingEnabled "RA8" False
+-SetNetComDataBufferSize "RA8" 3000
+
+#Acquisition Entity creation and setup for: "LOF1"
+-CreateCscAcqEnt "LOF1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF1" True
+-SetChannelNumber "LOF1" 15
+-SetAcqEntReference "LOF1" 32000000
+-SetInputRange "LOF1" 3000
+-SetSubSamplingInterleave "LOF1" 16
+-SetDspLowCutFilterEnabled "LOF1" True
+-SetDspLowCutFrequency "LOF1" 0.1
+-SetDspLowCutNumberTaps "LOF1" 0
+-SetDspHighCutFilterEnabled "LOF1" True
+-SetDspHighCutFrequency "LOF1" 500
+-SetDspHighCutNumberTaps "LOF1" 256
+-SetInputInverted "LOF1" True
+-SetNetComDataBufferingEnabled "LOF1" False
+-SetNetComDataBufferSize "LOF1" 3000
+
+#Acquisition Entity creation and setup for: "LOF2"
+-CreateCscAcqEnt "LOF2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF2" True
+-SetChannelNumber "LOF2" 16
+-SetAcqEntReference "LOF2" 32000000
+-SetInputRange "LOF2" 3000
+-SetSubSamplingInterleave "LOF2" 16
+-SetDspLowCutFilterEnabled "LOF2" True
+-SetDspLowCutFrequency "LOF2" 0.1
+-SetDspLowCutNumberTaps "LOF2" 0
+-SetDspHighCutFilterEnabled "LOF2" True
+-SetDspHighCutFrequency "LOF2" 500
+-SetDspHighCutNumberTaps "LOF2" 256
+-SetInputInverted "LOF2" True
+-SetNetComDataBufferingEnabled "LOF2" False
+-SetNetComDataBufferSize "LOF2" 3000
+
+#Acquisition Entity creation and setup for: "LOF3"
+-CreateCscAcqEnt "LOF3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF3" True
+-SetChannelNumber "LOF3" 17
+-SetAcqEntReference "LOF3" 32000000
+-SetInputRange "LOF3" 3000
+-SetSubSamplingInterleave "LOF3" 16
+-SetDspLowCutFilterEnabled "LOF3" True
+-SetDspLowCutFrequency "LOF3" 0.1
+-SetDspLowCutNumberTaps "LOF3" 0
+-SetDspHighCutFilterEnabled "LOF3" True
+-SetDspHighCutFrequency "LOF3" 500
+-SetDspHighCutNumberTaps "LOF3" 256
+-SetInputInverted "LOF3" True
+-SetNetComDataBufferingEnabled "LOF3" False
+-SetNetComDataBufferSize "LOF3" 3000
+
+#Acquisition Entity creation and setup for: "LOF4"
+-CreateCscAcqEnt "LOF4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF4" True
+-SetChannelNumber "LOF4" 18
+-SetAcqEntReference "LOF4" 32000000
+-SetInputRange "LOF4" 3000
+-SetSubSamplingInterleave "LOF4" 16
+-SetDspLowCutFilterEnabled "LOF4" True
+-SetDspLowCutFrequency "LOF4" 0.1
+-SetDspLowCutNumberTaps "LOF4" 0
+-SetDspHighCutFilterEnabled "LOF4" True
+-SetDspHighCutFrequency "LOF4" 500
+-SetDspHighCutNumberTaps "LOF4" 256
+-SetInputInverted "LOF4" True
+-SetNetComDataBufferingEnabled "LOF4" False
+-SetNetComDataBufferSize "LOF4" 3000
+
+#Acquisition Entity creation and setup for: "LOF5"
+-CreateCscAcqEnt "LOF5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF5" True
+-SetChannelNumber "LOF5" 19
+-SetAcqEntReference "LOF5" 32000000
+-SetInputRange "LOF5" 3000
+-SetSubSamplingInterleave "LOF5" 16
+-SetDspLowCutFilterEnabled "LOF5" True
+-SetDspLowCutFrequency "LOF5" 0.1
+-SetDspLowCutNumberTaps "LOF5" 0
+-SetDspHighCutFilterEnabled "LOF5" True
+-SetDspHighCutFrequency "LOF5" 500
+-SetDspHighCutNumberTaps "LOF5" 256
+-SetInputInverted "LOF5" True
+-SetNetComDataBufferingEnabled "LOF5" False
+-SetNetComDataBufferSize "LOF5" 3000
+
+#Acquisition Entity creation and setup for: "LOF6"
+-CreateCscAcqEnt "LOF6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF6" True
+-SetChannelNumber "LOF6" 20
+-SetAcqEntReference "LOF6" 32000000
+-SetInputRange "LOF6" 3000
+-SetSubSamplingInterleave "LOF6" 16
+-SetDspLowCutFilterEnabled "LOF6" True
+-SetDspLowCutFrequency "LOF6" 0.1
+-SetDspLowCutNumberTaps "LOF6" 0
+-SetDspHighCutFilterEnabled "LOF6" True
+-SetDspHighCutFrequency "LOF6" 500
+-SetDspHighCutNumberTaps "LOF6" 256
+-SetInputInverted "LOF6" True
+-SetNetComDataBufferingEnabled "LOF6" False
+-SetNetComDataBufferSize "LOF6" 3000
+
+#Acquisition Entity creation and setup for: "LOF7"
+-CreateCscAcqEnt "LOF7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF7" True
+-SetChannelNumber "LOF7" 21
+-SetAcqEntReference "LOF7" 32000000
+-SetInputRange "LOF7" 3000
+-SetSubSamplingInterleave "LOF7" 16
+-SetDspLowCutFilterEnabled "LOF7" True
+-SetDspLowCutFrequency "LOF7" 0.1
+-SetDspLowCutNumberTaps "LOF7" 0
+-SetDspHighCutFilterEnabled "LOF7" True
+-SetDspHighCutFrequency "LOF7" 500
+-SetDspHighCutNumberTaps "LOF7" 256
+-SetInputInverted "LOF7" True
+-SetNetComDataBufferingEnabled "LOF7" False
+-SetNetComDataBufferSize "LOF7" 3000
+
+#Acquisition Entity creation and setup for: "LOF8"
+-CreateCscAcqEnt "LOF8" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF8" True
+-SetChannelNumber "LOF8" 22
+-SetAcqEntReference "LOF8" 32000000
+-SetInputRange "LOF8" 3000
+-SetSubSamplingInterleave "LOF8" 16
+-SetDspLowCutFilterEnabled "LOF8" True
+-SetDspLowCutFrequency "LOF8" 0.1
+-SetDspLowCutNumberTaps "LOF8" 0
+-SetDspHighCutFilterEnabled "LOF8" True
+-SetDspHighCutFrequency "LOF8" 500
+-SetDspHighCutNumberTaps "LOF8" 256
+-SetInputInverted "LOF8" True
+-SetNetComDataBufferingEnabled "LOF8" False
+-SetNetComDataBufferSize "LOF8" 3000
+
+#Acquisition Entity creation and setup for: "ROF1"
+-CreateCscAcqEnt "ROF1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "ROF1" True
+-SetChannelNumber "ROF1" 23
+-SetAcqEntReference "ROF1" 32000000
+-SetInputRange "ROF1" 3000
+-SetSubSamplingInterleave "ROF1" 16
+-SetDspLowCutFilterEnabled "ROF1" True
+-SetDspLowCutFrequency "ROF1" 0.1
+-SetDspLowCutNumberTaps "ROF1" 0
+-SetDspHighCutFilterEnabled "ROF1" True
+-SetDspHighCutFrequency "ROF1" 500
+-SetDspHighCutNumberTaps "ROF1" 256
+-SetInputInverted "ROF1" True
+-SetNetComDataBufferingEnabled "ROF1" False
+-SetNetComDataBufferSize "ROF1" 3000
+
+#Acquisition Entity creation and setup for: "A1"
+-CreateCscAcqEnt "A1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "A1" False
+-SetChannelNumber "A1" 24
+-SetAcqEntReference "A1" 32000000
+-SetInputRange "A1" 3000
+-SetSubSamplingInterleave "A1" 16
+-SetDspLowCutFilterEnabled "A1" True
+-SetDspLowCutFrequency "A1" 0.1
+-SetDspLowCutNumberTaps "A1" 0
+-SetDspHighCutFilterEnabled "A1" True
+-SetDspHighCutFrequency "A1" 500
+-SetDspHighCutNumberTaps "A1" 256
+-SetInputInverted "A1" True
+-SetNetComDataBufferingEnabled "A1" False
+-SetNetComDataBufferSize "A1" 3000
+
+#Acquisition Entity creation and setup for: "A2"
+-CreateCscAcqEnt "A2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "A2" False
+-SetChannelNumber "A2" 25
+-SetAcqEntReference "A2" 32000000
+-SetInputRange "A2" 3000
+-SetSubSamplingInterleave "A2" 16
+-SetDspLowCutFilterEnabled "A2" True
+-SetDspLowCutFrequency "A2" 0.1
+-SetDspLowCutNumberTaps "A2" 0
+-SetDspHighCutFilterEnabled "A2" True
+-SetDspHighCutFrequency "A2" 500
+-SetDspHighCutNumberTaps "A2" 256
+-SetInputInverted "A2" True
+-SetNetComDataBufferingEnabled "A2" False
+-SetNetComDataBufferSize "A2" 3000
+
+#Acquisition Entity creation and setup for: "Analogue2"
+-CreateCscAcqEnt "Analogue2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "Analogue2" False
+-SetChannelNumber "Analogue2" 225
+-SetAcqEntReference "Analogue2" 32000007
+-SetInputRange "Analogue2" 800
+-SetSubSamplingInterleave "Analogue2" 1
+-SetDspLowCutFilterEnabled "Analogue2" True
+-SetDspLowCutFrequency "Analogue2" 0.1
+-SetDspLowCutNumberTaps "Analogue2" 0
+-SetDspHighCutFilterEnabled "Analogue2" True
+-SetDspHighCutFrequency "Analogue2" 8000
+-SetDspHighCutNumberTaps "Analogue2" 256
+-SetInputInverted "Analogue2" True
+-SetNetComDataBufferingEnabled "Analogue2" False
+-SetNetComDataBufferSize "Analogue2" 3000
+
+#Acquisition Entity creation and setup for: "Analogue3"
+-CreateCscAcqEnt "Analogue3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "Analogue3" False
+-SetChannelNumber "Analogue3" 226
+-SetAcqEntReference "Analogue3" 32000007
+-SetInputRange "Analogue3" 1500
+-SetSubSamplingInterleave "Analogue3" 1
+-SetDspLowCutFilterEnabled "Analogue3" True
+-SetDspLowCutFrequency "Analogue3" 0.1
+-SetDspLowCutNumberTaps "Analogue3" 0
+-SetDspHighCutFilterEnabled "Analogue3" True
+-SetDspHighCutFrequency "Analogue3" 8000
+-SetDspHighCutNumberTaps "Analogue3" 256
+-SetInputInverted "Analogue3" True
+-SetNetComDataBufferingEnabled "Analogue3" False
+-SetNetComDataBufferSize "Analogue3" 3000
+
+-CreateSpikeAcqEnt "SEGA1-LA1" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA1-LA1" True
+-SetChannelNumber "SEGA1-LA1" 0
+-SetInputRange "SEGA1-LA1" 400
+-SetSubSamplingInterleave "SEGA1-LA1" 1
+-SetDspLowCutFilterEnabled "SEGA1-LA1" True
+-SetDspLowCutFrequency "SEGA1-LA1" 600
+-SetDspLowCutNumberTaps "SEGA1-LA1" 256
+-SetDspHighCutFilterEnabled "SEGA1-LA1" True
+-SetDspHighCutFrequency "SEGA1-LA1" 6000
+-SetDspHighCutNumberTaps "SEGA1-LA1" 256
+-SetInputInverted "SEGA1-LA1" True
+-SetNetComDataBufferingEnabled "SEGA1-LA1" True
+-SetNetComDataBufferSize "SEGA1-LA1" 3000
+-SetSpikeThreshold "SEGA1-LA1" 45
+-SetSpikeDetectionType "SEGA1-LA1" Threshold
+-SetSpikeSlope "SEGA1-LA1" 0 100 160
+-SetSpikeDualThresholding "SEGA1-LA1" False
+-SetSpikeRetriggerTime "SEGA1-LA1" 750
+-SetSpikeAlignmentPoint "SEGA1-LA1" 8
+-SetSubChannelEnabled "SEGA1-LA1" 0 True
+-SetWaveformFeature "SEGA1-LA1" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA1-LA1" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA1-LA1" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA1-LA1" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA1-LA1" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA1-LA1" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA1-LA1" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA1-LA1" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA1-LA2" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA1-LA2" True
+-SetChannelNumber "SEGA1-LA2" 1
+-SetInputRange "SEGA1-LA2" 400
+-SetSubSamplingInterleave "SEGA1-LA2" 1
+-SetDspLowCutFilterEnabled "SEGA1-LA2" True
+-SetDspLowCutFrequency "SEGA1-LA2" 600
+-SetDspLowCutNumberTaps "SEGA1-LA2" 256
+-SetDspHighCutFilterEnabled "SEGA1-LA2" True
+-SetDspHighCutFrequency "SEGA1-LA2" 6000
+-SetDspHighCutNumberTaps "SEGA1-LA2" 256
+-SetInputInverted "SEGA1-LA2" True
+-SetNetComDataBufferingEnabled "SEGA1-LA2" True
+-SetNetComDataBufferSize "SEGA1-LA2" 3000
+-SetSpikeThreshold "SEGA1-LA2" 45
+-SetSpikeDetectionType "SEGA1-LA2" Threshold
+-SetSpikeSlope "SEGA1-LA2" 0 100 160
+-SetSpikeDualThresholding "SEGA1-LA2" False
+-SetSpikeRetriggerTime "SEGA1-LA2" 750
+-SetSpikeAlignmentPoint "SEGA1-LA2" 8
+-SetSubChannelEnabled "SEGA1-LA2" 0 True
+-SetWaveformFeature "SEGA1-LA2" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA1-LA2" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA1-LA2" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA1-LA2" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA1-LA2" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA1-LA2" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA1-LA2" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA1-LA2" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA1-LA3" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA1-LA3" True
+-SetChannelNumber "SEGA1-LA3" 2
+-SetInputRange "SEGA1-LA3" 400
+-SetSubSamplingInterleave "SEGA1-LA3" 1
+-SetDspLowCutFilterEnabled "SEGA1-LA3" True
+-SetDspLowCutFrequency "SEGA1-LA3" 600
+-SetDspLowCutNumberTaps "SEGA1-LA3" 256
+-SetDspHighCutFilterEnabled "SEGA1-LA3" True
+-SetDspHighCutFrequency "SEGA1-LA3" 6000
+-SetDspHighCutNumberTaps "SEGA1-LA3" 256
+-SetInputInverted "SEGA1-LA3" True
+-SetNetComDataBufferingEnabled "SEGA1-LA3" True
+-SetNetComDataBufferSize "SEGA1-LA3" 3000
+-SetSpikeThreshold "SEGA1-LA3" 45
+-SetSpikeDetectionType "SEGA1-LA3" Threshold
+-SetSpikeSlope "SEGA1-LA3" 0 100 160
+-SetSpikeDualThresholding "SEGA1-LA3" False
+-SetSpikeRetriggerTime "SEGA1-LA3" 750
+-SetSpikeAlignmentPoint "SEGA1-LA3" 8
+-SetSubChannelEnabled "SEGA1-LA3" 0 True
+-SetWaveformFeature "SEGA1-LA3" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA1-LA3" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA1-LA3" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA1-LA3" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA1-LA3" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA1-LA3" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA1-LA3" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA1-LA3" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA1-LA4" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA1-LA4" True
+-SetChannelNumber "SEGA1-LA4" 3
+-SetInputRange "SEGA1-LA4" 400
+-SetSubSamplingInterleave "SEGA1-LA4" 1
+-SetDspLowCutFilterEnabled "SEGA1-LA4" True
+-SetDspLowCutFrequency "SEGA1-LA4" 600
+-SetDspLowCutNumberTaps "SEGA1-LA4" 256
+-SetDspHighCutFilterEnabled "SEGA1-LA4" True
+-SetDspHighCutFrequency "SEGA1-LA4" 6000
+-SetDspHighCutNumberTaps "SEGA1-LA4" 256
+-SetInputInverted "SEGA1-LA4" True
+-SetNetComDataBufferingEnabled "SEGA1-LA4" True
+-SetNetComDataBufferSize "SEGA1-LA4" 3000
+-SetSpikeThreshold "SEGA1-LA4" 45
+-SetSpikeDetectionType "SEGA1-LA4" Threshold
+-SetSpikeSlope "SEGA1-LA4" 0 100 160
+-SetSpikeDualThresholding "SEGA1-LA4" False
+-SetSpikeRetriggerTime "SEGA1-LA4" 750
+-SetSpikeAlignmentPoint "SEGA1-LA4" 8
+-SetSubChannelEnabled "SEGA1-LA4" 0 True
+-SetWaveformFeature "SEGA1-LA4" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA1-LA4" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA1-LA4" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA1-LA4" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA1-LA4" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA1-LA4" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA1-LA4" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA1-LA4" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA1-LA5" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA1-LA5" True
+-SetChannelNumber "SEGA1-LA5" 4
+-SetInputRange "SEGA1-LA5" 400
+-SetSubSamplingInterleave "SEGA1-LA5" 1
+-SetDspLowCutFilterEnabled "SEGA1-LA5" True
+-SetDspLowCutFrequency "SEGA1-LA5" 600
+-SetDspLowCutNumberTaps "SEGA1-LA5" 256
+-SetDspHighCutFilterEnabled "SEGA1-LA5" True
+-SetDspHighCutFrequency "SEGA1-LA5" 6000
+-SetDspHighCutNumberTaps "SEGA1-LA5" 256
+-SetInputInverted "SEGA1-LA5" True
+-SetNetComDataBufferingEnabled "SEGA1-LA5" True
+-SetNetComDataBufferSize "SEGA1-LA5" 3000
+-SetSpikeThreshold "SEGA1-LA5" 45
+-SetSpikeDetectionType "SEGA1-LA5" Threshold
+-SetSpikeSlope "SEGA1-LA5" 0 100 160
+-SetSpikeDualThresholding "SEGA1-LA5" False
+-SetSpikeRetriggerTime "SEGA1-LA5" 750
+-SetSpikeAlignmentPoint "SEGA1-LA5" 8
+-SetSubChannelEnabled "SEGA1-LA5" 0 True
+-SetWaveformFeature "SEGA1-LA5" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA1-LA5" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA1-LA5" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA1-LA5" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA1-LA5" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA1-LA5" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA1-LA5" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA1-LA5" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA1-LA6" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA1-LA6" True
+-SetChannelNumber "SEGA1-LA6" 5
+-SetInputRange "SEGA1-LA6" 400
+-SetSubSamplingInterleave "SEGA1-LA6" 1
+-SetDspLowCutFilterEnabled "SEGA1-LA6" True
+-SetDspLowCutFrequency "SEGA1-LA6" 600
+-SetDspLowCutNumberTaps "SEGA1-LA6" 256
+-SetDspHighCutFilterEnabled "SEGA1-LA6" True
+-SetDspHighCutFrequency "SEGA1-LA6" 6000
+-SetDspHighCutNumberTaps "SEGA1-LA6" 256
+-SetInputInverted "SEGA1-LA6" True
+-SetNetComDataBufferingEnabled "SEGA1-LA6" True
+-SetNetComDataBufferSize "SEGA1-LA6" 3000
+-SetSpikeThreshold "SEGA1-LA6" 45
+-SetSpikeDetectionType "SEGA1-LA6" Threshold
+-SetSpikeSlope "SEGA1-LA6" 0 100 160
+-SetSpikeDualThresholding "SEGA1-LA6" False
+-SetSpikeRetriggerTime "SEGA1-LA6" 750
+-SetSpikeAlignmentPoint "SEGA1-LA6" 8
+-SetSubChannelEnabled "SEGA1-LA6" 0 True
+-SetWaveformFeature "SEGA1-LA6" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA1-LA6" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA1-LA6" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA1-LA6" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA1-LA6" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA1-LA6" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA1-LA6" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA1-LA6" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA1-LA7" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA1-LA7" True
+-SetChannelNumber "SEGA1-LA7" 6
+-SetInputRange "SEGA1-LA7" 400
+-SetSubSamplingInterleave "SEGA1-LA7" 1
+-SetDspLowCutFilterEnabled "SEGA1-LA7" True
+-SetDspLowCutFrequency "SEGA1-LA7" 600
+-SetDspLowCutNumberTaps "SEGA1-LA7" 256
+-SetDspHighCutFilterEnabled "SEGA1-LA7" True
+-SetDspHighCutFrequency "SEGA1-LA7" 6000
+-SetDspHighCutNumberTaps "SEGA1-LA7" 256
+-SetInputInverted "SEGA1-LA7" True
+-SetNetComDataBufferingEnabled "SEGA1-LA7" True
+-SetNetComDataBufferSize "SEGA1-LA7" 3000
+-SetSpikeThreshold "SEGA1-LA7" 45
+-SetSpikeDetectionType "SEGA1-LA7" Threshold
+-SetSpikeSlope "SEGA1-LA7" 0 100 160
+-SetSpikeDualThresholding "SEGA1-LA7" False
+-SetSpikeRetriggerTime "SEGA1-LA7" 750
+-SetSpikeAlignmentPoint "SEGA1-LA7" 8
+-SetSubChannelEnabled "SEGA1-LA7" 0 True
+-SetWaveformFeature "SEGA1-LA7" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA1-LA7" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA1-LA7" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA1-LA7" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA1-LA7" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA1-LA7" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA1-LA7" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA1-LA7" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA1-LA8" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA1-LA8" True
+-SetChannelNumber "SEGA1-LA8" 7
+-SetInputRange "SEGA1-LA8" 400
+-SetSubSamplingInterleave "SEGA1-LA8" 1
+-SetDspLowCutFilterEnabled "SEGA1-LA8" True
+-SetDspLowCutFrequency "SEGA1-LA8" 600
+-SetDspLowCutNumberTaps "SEGA1-LA8" 256
+-SetDspHighCutFilterEnabled "SEGA1-LA8" True
+-SetDspHighCutFrequency "SEGA1-LA8" 6000
+-SetDspHighCutNumberTaps "SEGA1-LA8" 256
+-SetInputInverted "SEGA1-LA8" True
+-SetNetComDataBufferingEnabled "SEGA1-LA8" True
+-SetNetComDataBufferSize "SEGA1-LA8" 3000
+-SetSpikeThreshold "SEGA1-LA8" 45
+-SetSpikeDetectionType "SEGA1-LA8" Threshold
+-SetSpikeSlope "SEGA1-LA8" 0 100 160
+-SetSpikeDualThresholding "SEGA1-LA8" False
+-SetSpikeRetriggerTime "SEGA1-LA8" 750
+-SetSpikeAlignmentPoint "SEGA1-LA8" 8
+-SetSubChannelEnabled "SEGA1-LA8" 0 True
+-SetWaveformFeature "SEGA1-LA8" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA1-LA8" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA1-LA8" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA1-LA8" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA1-LA8" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA1-LA8" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA1-LA8" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA1-LA8" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA2-LAC1" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA2-LAC1" True
+-SetChannelNumber "SEGA2-LAC1" 8
+-SetInputRange "SEGA2-LAC1" 400
+-SetSubSamplingInterleave "SEGA2-LAC1" 1
+-SetDspLowCutFilterEnabled "SEGA2-LAC1" True
+-SetDspLowCutFrequency "SEGA2-LAC1" 600
+-SetDspLowCutNumberTaps "SEGA2-LAC1" 256
+-SetDspHighCutFilterEnabled "SEGA2-LAC1" True
+-SetDspHighCutFrequency "SEGA2-LAC1" 6000
+-SetDspHighCutNumberTaps "SEGA2-LAC1" 256
+-SetInputInverted "SEGA2-LAC1" True
+-SetNetComDataBufferingEnabled "SEGA2-LAC1" True
+-SetNetComDataBufferSize "SEGA2-LAC1" 3000
+-SetSpikeThreshold "SEGA2-LAC1" 45
+-SetSpikeDetectionType "SEGA2-LAC1" Threshold
+-SetSpikeSlope "SEGA2-LAC1" 0 100 160
+-SetSpikeDualThresholding "SEGA2-LAC1" False
+-SetSpikeRetriggerTime "SEGA2-LAC1" 750
+-SetSpikeAlignmentPoint "SEGA2-LAC1" 8
+-SetSubChannelEnabled "SEGA2-LAC1" 0 True
+-SetWaveformFeature "SEGA2-LAC1" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC1" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC1" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC1" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC1" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA2-LAC1" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA2-LAC1" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA2-LAC1" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA2-LAC2" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA2-LAC2" True
+-SetChannelNumber "SEGA2-LAC2" 9
+-SetInputRange "SEGA2-LAC2" 400
+-SetSubSamplingInterleave "SEGA2-LAC2" 1
+-SetDspLowCutFilterEnabled "SEGA2-LAC2" True
+-SetDspLowCutFrequency "SEGA2-LAC2" 600
+-SetDspLowCutNumberTaps "SEGA2-LAC2" 256
+-SetDspHighCutFilterEnabled "SEGA2-LAC2" True
+-SetDspHighCutFrequency "SEGA2-LAC2" 6000
+-SetDspHighCutNumberTaps "SEGA2-LAC2" 256
+-SetInputInverted "SEGA2-LAC2" True
+-SetNetComDataBufferingEnabled "SEGA2-LAC2" True
+-SetNetComDataBufferSize "SEGA2-LAC2" 3000
+-SetSpikeThreshold "SEGA2-LAC2" 45
+-SetSpikeDetectionType "SEGA2-LAC2" Threshold
+-SetSpikeSlope "SEGA2-LAC2" 0 100 160
+-SetSpikeDualThresholding "SEGA2-LAC2" False
+-SetSpikeRetriggerTime "SEGA2-LAC2" 750
+-SetSpikeAlignmentPoint "SEGA2-LAC2" 8
+-SetSubChannelEnabled "SEGA2-LAC2" 0 True
+-SetWaveformFeature "SEGA2-LAC2" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC2" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC2" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC2" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC2" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA2-LAC2" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA2-LAC2" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA2-LAC2" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA2-LAC3" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA2-LAC3" True
+-SetChannelNumber "SEGA2-LAC3" 10
+-SetInputRange "SEGA2-LAC3" 400
+-SetSubSamplingInterleave "SEGA2-LAC3" 1
+-SetDspLowCutFilterEnabled "SEGA2-LAC3" True
+-SetDspLowCutFrequency "SEGA2-LAC3" 600
+-SetDspLowCutNumberTaps "SEGA2-LAC3" 256
+-SetDspHighCutFilterEnabled "SEGA2-LAC3" True
+-SetDspHighCutFrequency "SEGA2-LAC3" 6000
+-SetDspHighCutNumberTaps "SEGA2-LAC3" 256
+-SetInputInverted "SEGA2-LAC3" True
+-SetNetComDataBufferingEnabled "SEGA2-LAC3" True
+-SetNetComDataBufferSize "SEGA2-LAC3" 3000
+-SetSpikeThreshold "SEGA2-LAC3" 45
+-SetSpikeDetectionType "SEGA2-LAC3" Threshold
+-SetSpikeSlope "SEGA2-LAC3" 0 100 160
+-SetSpikeDualThresholding "SEGA2-LAC3" False
+-SetSpikeRetriggerTime "SEGA2-LAC3" 750
+-SetSpikeAlignmentPoint "SEGA2-LAC3" 8
+-SetSubChannelEnabled "SEGA2-LAC3" 0 True
+-SetWaveformFeature "SEGA2-LAC3" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC3" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC3" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC3" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC3" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA2-LAC3" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA2-LAC3" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA2-LAC3" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA2-LAC4" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA2-LAC4" True
+-SetChannelNumber "SEGA2-LAC4" 11
+-SetInputRange "SEGA2-LAC4" 400
+-SetSubSamplingInterleave "SEGA2-LAC4" 1
+-SetDspLowCutFilterEnabled "SEGA2-LAC4" True
+-SetDspLowCutFrequency "SEGA2-LAC4" 600
+-SetDspLowCutNumberTaps "SEGA2-LAC4" 256
+-SetDspHighCutFilterEnabled "SEGA2-LAC4" True
+-SetDspHighCutFrequency "SEGA2-LAC4" 6000
+-SetDspHighCutNumberTaps "SEGA2-LAC4" 256
+-SetInputInverted "SEGA2-LAC4" True
+-SetNetComDataBufferingEnabled "SEGA2-LAC4" True
+-SetNetComDataBufferSize "SEGA2-LAC4" 3000
+-SetSpikeThreshold "SEGA2-LAC4" 45
+-SetSpikeDetectionType "SEGA2-LAC4" Threshold
+-SetSpikeSlope "SEGA2-LAC4" 0 100 160
+-SetSpikeDualThresholding "SEGA2-LAC4" False
+-SetSpikeRetriggerTime "SEGA2-LAC4" 750
+-SetSpikeAlignmentPoint "SEGA2-LAC4" 8
+-SetSubChannelEnabled "SEGA2-LAC4" 0 True
+-SetWaveformFeature "SEGA2-LAC4" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC4" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC4" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC4" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC4" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA2-LAC4" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA2-LAC4" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA2-LAC4" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA2-LAC5" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA2-LAC5" True
+-SetChannelNumber "SEGA2-LAC5" 12
+-SetInputRange "SEGA2-LAC5" 400
+-SetSubSamplingInterleave "SEGA2-LAC5" 1
+-SetDspLowCutFilterEnabled "SEGA2-LAC5" True
+-SetDspLowCutFrequency "SEGA2-LAC5" 600
+-SetDspLowCutNumberTaps "SEGA2-LAC5" 256
+-SetDspHighCutFilterEnabled "SEGA2-LAC5" True
+-SetDspHighCutFrequency "SEGA2-LAC5" 6000
+-SetDspHighCutNumberTaps "SEGA2-LAC5" 256
+-SetInputInverted "SEGA2-LAC5" True
+-SetNetComDataBufferingEnabled "SEGA2-LAC5" True
+-SetNetComDataBufferSize "SEGA2-LAC5" 3000
+-SetSpikeThreshold "SEGA2-LAC5" 45
+-SetSpikeDetectionType "SEGA2-LAC5" Threshold
+-SetSpikeSlope "SEGA2-LAC5" 0 100 160
+-SetSpikeDualThresholding "SEGA2-LAC5" False
+-SetSpikeRetriggerTime "SEGA2-LAC5" 750
+-SetSpikeAlignmentPoint "SEGA2-LAC5" 8
+-SetSubChannelEnabled "SEGA2-LAC5" 0 True
+-SetWaveformFeature "SEGA2-LAC5" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC5" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC5" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC5" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC5" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA2-LAC5" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA2-LAC5" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA2-LAC5" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA2-LAC6" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA2-LAC6" True
+-SetChannelNumber "SEGA2-LAC6" 13
+-SetInputRange "SEGA2-LAC6" 400
+-SetSubSamplingInterleave "SEGA2-LAC6" 1
+-SetDspLowCutFilterEnabled "SEGA2-LAC6" True
+-SetDspLowCutFrequency "SEGA2-LAC6" 600
+-SetDspLowCutNumberTaps "SEGA2-LAC6" 256
+-SetDspHighCutFilterEnabled "SEGA2-LAC6" True
+-SetDspHighCutFrequency "SEGA2-LAC6" 6000
+-SetDspHighCutNumberTaps "SEGA2-LAC6" 256
+-SetInputInverted "SEGA2-LAC6" True
+-SetNetComDataBufferingEnabled "SEGA2-LAC6" True
+-SetNetComDataBufferSize "SEGA2-LAC6" 3000
+-SetSpikeThreshold "SEGA2-LAC6" 45
+-SetSpikeDetectionType "SEGA2-LAC6" Threshold
+-SetSpikeSlope "SEGA2-LAC6" 0 100 160
+-SetSpikeDualThresholding "SEGA2-LAC6" False
+-SetSpikeRetriggerTime "SEGA2-LAC6" 750
+-SetSpikeAlignmentPoint "SEGA2-LAC6" 8
+-SetSubChannelEnabled "SEGA2-LAC6" 0 True
+-SetWaveformFeature "SEGA2-LAC6" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC6" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC6" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC6" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC6" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA2-LAC6" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA2-LAC6" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA2-LAC6" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA2-LAC7" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA2-LAC7" True
+-SetChannelNumber "SEGA2-LAC7" 14
+-SetInputRange "SEGA2-LAC7" 400
+-SetSubSamplingInterleave "SEGA2-LAC7" 1
+-SetDspLowCutFilterEnabled "SEGA2-LAC7" True
+-SetDspLowCutFrequency "SEGA2-LAC7" 600
+-SetDspLowCutNumberTaps "SEGA2-LAC7" 256
+-SetDspHighCutFilterEnabled "SEGA2-LAC7" True
+-SetDspHighCutFrequency "SEGA2-LAC7" 6000
+-SetDspHighCutNumberTaps "SEGA2-LAC7" 256
+-SetInputInverted "SEGA2-LAC7" True
+-SetNetComDataBufferingEnabled "SEGA2-LAC7" True
+-SetNetComDataBufferSize "SEGA2-LAC7" 3000
+-SetSpikeThreshold "SEGA2-LAC7" 45
+-SetSpikeDetectionType "SEGA2-LAC7" Threshold
+-SetSpikeSlope "SEGA2-LAC7" 0 100 160
+-SetSpikeDualThresholding "SEGA2-LAC7" False
+-SetSpikeRetriggerTime "SEGA2-LAC7" 750
+-SetSpikeAlignmentPoint "SEGA2-LAC7" 8
+-SetSubChannelEnabled "SEGA2-LAC7" 0 True
+-SetWaveformFeature "SEGA2-LAC7" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC7" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC7" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC7" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC7" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA2-LAC7" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA2-LAC7" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA2-LAC7" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA2-LAC8" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA2-LAC8" True
+-SetChannelNumber "SEGA2-LAC8" 15
+-SetInputRange "SEGA2-LAC8" 400
+-SetSubSamplingInterleave "SEGA2-LAC8" 1
+-SetDspLowCutFilterEnabled "SEGA2-LAC8" True
+-SetDspLowCutFrequency "SEGA2-LAC8" 600
+-SetDspLowCutNumberTaps "SEGA2-LAC8" 256
+-SetDspHighCutFilterEnabled "SEGA2-LAC8" True
+-SetDspHighCutFrequency "SEGA2-LAC8" 6000
+-SetDspHighCutNumberTaps "SEGA2-LAC8" 256
+-SetInputInverted "SEGA2-LAC8" True
+-SetNetComDataBufferingEnabled "SEGA2-LAC8" True
+-SetNetComDataBufferSize "SEGA2-LAC8" 3000
+-SetSpikeThreshold "SEGA2-LAC8" 45
+-SetSpikeDetectionType "SEGA2-LAC8" Threshold
+-SetSpikeSlope "SEGA2-LAC8" 0 100 160
+-SetSpikeDualThresholding "SEGA2-LAC8" False
+-SetSpikeRetriggerTime "SEGA2-LAC8" 750
+-SetSpikeAlignmentPoint "SEGA2-LAC8" 8
+-SetSubChannelEnabled "SEGA2-LAC8" 0 True
+-SetWaveformFeature "SEGA2-LAC8" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC8" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC8" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC8" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA2-LAC8" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA2-LAC8" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA2-LAC8" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA2-LAC8" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA3-LACd1" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA3-LACd1" True
+-SetChannelNumber "SEGA3-LACd1" 16
+-SetInputRange "SEGA3-LACd1" 400
+-SetSubSamplingInterleave "SEGA3-LACd1" 1
+-SetDspLowCutFilterEnabled "SEGA3-LACd1" True
+-SetDspLowCutFrequency "SEGA3-LACd1" 600
+-SetDspLowCutNumberTaps "SEGA3-LACd1" 256
+-SetDspHighCutFilterEnabled "SEGA3-LACd1" True
+-SetDspHighCutFrequency "SEGA3-LACd1" 6000
+-SetDspHighCutNumberTaps "SEGA3-LACd1" 256
+-SetInputInverted "SEGA3-LACd1" True
+-SetNetComDataBufferingEnabled "SEGA3-LACd1" True
+-SetNetComDataBufferSize "SEGA3-LACd1" 3000
+-SetSpikeThreshold "SEGA3-LACd1" 45
+-SetSpikeDetectionType "SEGA3-LACd1" Threshold
+-SetSpikeSlope "SEGA3-LACd1" 0 100 160
+-SetSpikeDualThresholding "SEGA3-LACd1" False
+-SetSpikeRetriggerTime "SEGA3-LACd1" 750
+-SetSpikeAlignmentPoint "SEGA3-LACd1" 8
+-SetSubChannelEnabled "SEGA3-LACd1" 0 True
+-SetWaveformFeature "SEGA3-LACd1" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd1" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd1" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd1" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd1" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA3-LACd1" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA3-LACd1" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA3-LACd1" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA3-LACd2" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA3-LACd2" True
+-SetChannelNumber "SEGA3-LACd2" 17
+-SetInputRange "SEGA3-LACd2" 400
+-SetSubSamplingInterleave "SEGA3-LACd2" 1
+-SetDspLowCutFilterEnabled "SEGA3-LACd2" True
+-SetDspLowCutFrequency "SEGA3-LACd2" 600
+-SetDspLowCutNumberTaps "SEGA3-LACd2" 256
+-SetDspHighCutFilterEnabled "SEGA3-LACd2" True
+-SetDspHighCutFrequency "SEGA3-LACd2" 6000
+-SetDspHighCutNumberTaps "SEGA3-LACd2" 256
+-SetInputInverted "SEGA3-LACd2" True
+-SetNetComDataBufferingEnabled "SEGA3-LACd2" True
+-SetNetComDataBufferSize "SEGA3-LACd2" 3000
+-SetSpikeThreshold "SEGA3-LACd2" 45
+-SetSpikeDetectionType "SEGA3-LACd2" Threshold
+-SetSpikeSlope "SEGA3-LACd2" 0 100 160
+-SetSpikeDualThresholding "SEGA3-LACd2" False
+-SetSpikeRetriggerTime "SEGA3-LACd2" 750
+-SetSpikeAlignmentPoint "SEGA3-LACd2" 8
+-SetSubChannelEnabled "SEGA3-LACd2" 0 True
+-SetWaveformFeature "SEGA3-LACd2" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd2" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd2" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd2" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd2" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA3-LACd2" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA3-LACd2" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA3-LACd2" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA3-LACd3" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA3-LACd3" True
+-SetChannelNumber "SEGA3-LACd3" 18
+-SetInputRange "SEGA3-LACd3" 400
+-SetSubSamplingInterleave "SEGA3-LACd3" 1
+-SetDspLowCutFilterEnabled "SEGA3-LACd3" True
+-SetDspLowCutFrequency "SEGA3-LACd3" 600
+-SetDspLowCutNumberTaps "SEGA3-LACd3" 256
+-SetDspHighCutFilterEnabled "SEGA3-LACd3" True
+-SetDspHighCutFrequency "SEGA3-LACd3" 6000
+-SetDspHighCutNumberTaps "SEGA3-LACd3" 256
+-SetInputInverted "SEGA3-LACd3" True
+-SetNetComDataBufferingEnabled "SEGA3-LACd3" True
+-SetNetComDataBufferSize "SEGA3-LACd3" 3000
+-SetSpikeThreshold "SEGA3-LACd3" 45
+-SetSpikeDetectionType "SEGA3-LACd3" Threshold
+-SetSpikeSlope "SEGA3-LACd3" 0 100 160
+-SetSpikeDualThresholding "SEGA3-LACd3" False
+-SetSpikeRetriggerTime "SEGA3-LACd3" 750
+-SetSpikeAlignmentPoint "SEGA3-LACd3" 8
+-SetSubChannelEnabled "SEGA3-LACd3" 0 True
+-SetWaveformFeature "SEGA3-LACd3" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd3" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd3" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd3" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd3" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA3-LACd3" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA3-LACd3" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA3-LACd3" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA3-LACd4" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA3-LACd4" True
+-SetChannelNumber "SEGA3-LACd4" 19
+-SetInputRange "SEGA3-LACd4" 400
+-SetSubSamplingInterleave "SEGA3-LACd4" 1
+-SetDspLowCutFilterEnabled "SEGA3-LACd4" True
+-SetDspLowCutFrequency "SEGA3-LACd4" 600
+-SetDspLowCutNumberTaps "SEGA3-LACd4" 256
+-SetDspHighCutFilterEnabled "SEGA3-LACd4" True
+-SetDspHighCutFrequency "SEGA3-LACd4" 6000
+-SetDspHighCutNumberTaps "SEGA3-LACd4" 256
+-SetInputInverted "SEGA3-LACd4" True
+-SetNetComDataBufferingEnabled "SEGA3-LACd4" True
+-SetNetComDataBufferSize "SEGA3-LACd4" 3000
+-SetSpikeThreshold "SEGA3-LACd4" 45
+-SetSpikeDetectionType "SEGA3-LACd4" Threshold
+-SetSpikeSlope "SEGA3-LACd4" 0 100 160
+-SetSpikeDualThresholding "SEGA3-LACd4" False
+-SetSpikeRetriggerTime "SEGA3-LACd4" 750
+-SetSpikeAlignmentPoint "SEGA3-LACd4" 8
+-SetSubChannelEnabled "SEGA3-LACd4" 0 True
+-SetWaveformFeature "SEGA3-LACd4" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd4" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd4" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd4" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd4" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA3-LACd4" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA3-LACd4" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA3-LACd4" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA3-LACd5" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA3-LACd5" True
+-SetChannelNumber "SEGA3-LACd5" 20
+-SetInputRange "SEGA3-LACd5" 400
+-SetSubSamplingInterleave "SEGA3-LACd5" 1
+-SetDspLowCutFilterEnabled "SEGA3-LACd5" True
+-SetDspLowCutFrequency "SEGA3-LACd5" 600
+-SetDspLowCutNumberTaps "SEGA3-LACd5" 256
+-SetDspHighCutFilterEnabled "SEGA3-LACd5" True
+-SetDspHighCutFrequency "SEGA3-LACd5" 6000
+-SetDspHighCutNumberTaps "SEGA3-LACd5" 256
+-SetInputInverted "SEGA3-LACd5" True
+-SetNetComDataBufferingEnabled "SEGA3-LACd5" True
+-SetNetComDataBufferSize "SEGA3-LACd5" 3000
+-SetSpikeThreshold "SEGA3-LACd5" 45
+-SetSpikeDetectionType "SEGA3-LACd5" Threshold
+-SetSpikeSlope "SEGA3-LACd5" 0 100 160
+-SetSpikeDualThresholding "SEGA3-LACd5" False
+-SetSpikeRetriggerTime "SEGA3-LACd5" 750
+-SetSpikeAlignmentPoint "SEGA3-LACd5" 8
+-SetSubChannelEnabled "SEGA3-LACd5" 0 True
+-SetWaveformFeature "SEGA3-LACd5" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd5" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd5" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd5" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd5" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA3-LACd5" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA3-LACd5" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA3-LACd5" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA3-LACd6" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA3-LACd6" True
+-SetChannelNumber "SEGA3-LACd6" 21
+-SetInputRange "SEGA3-LACd6" 400
+-SetSubSamplingInterleave "SEGA3-LACd6" 1
+-SetDspLowCutFilterEnabled "SEGA3-LACd6" True
+-SetDspLowCutFrequency "SEGA3-LACd6" 600
+-SetDspLowCutNumberTaps "SEGA3-LACd6" 256
+-SetDspHighCutFilterEnabled "SEGA3-LACd6" True
+-SetDspHighCutFrequency "SEGA3-LACd6" 6000
+-SetDspHighCutNumberTaps "SEGA3-LACd6" 256
+-SetInputInverted "SEGA3-LACd6" True
+-SetNetComDataBufferingEnabled "SEGA3-LACd6" True
+-SetNetComDataBufferSize "SEGA3-LACd6" 3000
+-SetSpikeThreshold "SEGA3-LACd6" 45
+-SetSpikeDetectionType "SEGA3-LACd6" Threshold
+-SetSpikeSlope "SEGA3-LACd6" 0 100 160
+-SetSpikeDualThresholding "SEGA3-LACd6" False
+-SetSpikeRetriggerTime "SEGA3-LACd6" 750
+-SetSpikeAlignmentPoint "SEGA3-LACd6" 8
+-SetSubChannelEnabled "SEGA3-LACd6" 0 True
+-SetWaveformFeature "SEGA3-LACd6" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd6" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd6" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd6" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd6" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA3-LACd6" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA3-LACd6" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA3-LACd6" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA3-LACd7" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA3-LACd7" True
+-SetChannelNumber "SEGA3-LACd7" 22
+-SetInputRange "SEGA3-LACd7" 400
+-SetSubSamplingInterleave "SEGA3-LACd7" 1
+-SetDspLowCutFilterEnabled "SEGA3-LACd7" True
+-SetDspLowCutFrequency "SEGA3-LACd7" 600
+-SetDspLowCutNumberTaps "SEGA3-LACd7" 256
+-SetDspHighCutFilterEnabled "SEGA3-LACd7" True
+-SetDspHighCutFrequency "SEGA3-LACd7" 6000
+-SetDspHighCutNumberTaps "SEGA3-LACd7" 256
+-SetInputInverted "SEGA3-LACd7" True
+-SetNetComDataBufferingEnabled "SEGA3-LACd7" True
+-SetNetComDataBufferSize "SEGA3-LACd7" 3000
+-SetSpikeThreshold "SEGA3-LACd7" 45
+-SetSpikeDetectionType "SEGA3-LACd7" Threshold
+-SetSpikeSlope "SEGA3-LACd7" 0 100 160
+-SetSpikeDualThresholding "SEGA3-LACd7" False
+-SetSpikeRetriggerTime "SEGA3-LACd7" 750
+-SetSpikeAlignmentPoint "SEGA3-LACd7" 8
+-SetSubChannelEnabled "SEGA3-LACd7" 0 True
+-SetWaveformFeature "SEGA3-LACd7" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd7" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd7" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd7" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd7" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA3-LACd7" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA3-LACd7" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA3-LACd7" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGA3-LACd8" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGA3-LACd8" True
+-SetChannelNumber "SEGA3-LACd8" 23
+-SetInputRange "SEGA3-LACd8" 400
+-SetSubSamplingInterleave "SEGA3-LACd8" 1
+-SetDspLowCutFilterEnabled "SEGA3-LACd8" True
+-SetDspLowCutFrequency "SEGA3-LACd8" 600
+-SetDspLowCutNumberTaps "SEGA3-LACd8" 256
+-SetDspHighCutFilterEnabled "SEGA3-LACd8" True
+-SetDspHighCutFrequency "SEGA3-LACd8" 6000
+-SetDspHighCutNumberTaps "SEGA3-LACd8" 256
+-SetInputInverted "SEGA3-LACd8" True
+-SetNetComDataBufferingEnabled "SEGA3-LACd8" True
+-SetNetComDataBufferSize "SEGA3-LACd8" 3000
+-SetSpikeThreshold "SEGA3-LACd8" 45
+-SetSpikeDetectionType "SEGA3-LACd8" Threshold
+-SetSpikeSlope "SEGA3-LACd8" 0 100 160
+-SetSpikeDualThresholding "SEGA3-LACd8" False
+-SetSpikeRetriggerTime "SEGA3-LACd8" 750
+-SetSpikeAlignmentPoint "SEGA3-LACd8" 8
+-SetSubChannelEnabled "SEGA3-LACd8" 0 True
+-SetWaveformFeature "SEGA3-LACd8" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd8" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd8" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd8" Height 3 0 0 31 1
+-SetWaveformFeature "SEGA3-LACd8" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGA3-LACd8" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGA3-LACd8" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGA3-LACd8" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB1-RA1" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB1-RA1" True
+-SetChannelNumber "SEGB1-RA1" 32
+-SetInputRange "SEGB1-RA1" 400
+-SetSubSamplingInterleave "SEGB1-RA1" 1
+-SetDspLowCutFilterEnabled "SEGB1-RA1" True
+-SetDspLowCutFrequency "SEGB1-RA1" 600
+-SetDspLowCutNumberTaps "SEGB1-RA1" 256
+-SetDspHighCutFilterEnabled "SEGB1-RA1" True
+-SetDspHighCutFrequency "SEGB1-RA1" 6000
+-SetDspHighCutNumberTaps "SEGB1-RA1" 256
+-SetInputInverted "SEGB1-RA1" True
+-SetNetComDataBufferingEnabled "SEGB1-RA1" True
+-SetNetComDataBufferSize "SEGB1-RA1" 3000
+-SetSpikeThreshold "SEGB1-RA1" 45
+-SetSpikeDetectionType "SEGB1-RA1" Threshold
+-SetSpikeSlope "SEGB1-RA1" 0 100 160
+-SetSpikeDualThresholding "SEGB1-RA1" False
+-SetSpikeRetriggerTime "SEGB1-RA1" 750
+-SetSpikeAlignmentPoint "SEGB1-RA1" 8
+-SetSubChannelEnabled "SEGB1-RA1" 0 True
+-SetWaveformFeature "SEGB1-RA1" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB1-RA1" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB1-RA1" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB1-RA1" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB1-RA1" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB1-RA1" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB1-RA1" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB1-RA1" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB1-RA2" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB1-RA2" True
+-SetChannelNumber "SEGB1-RA2" 33
+-SetInputRange "SEGB1-RA2" 400
+-SetSubSamplingInterleave "SEGB1-RA2" 1
+-SetDspLowCutFilterEnabled "SEGB1-RA2" True
+-SetDspLowCutFrequency "SEGB1-RA2" 600
+-SetDspLowCutNumberTaps "SEGB1-RA2" 256
+-SetDspHighCutFilterEnabled "SEGB1-RA2" True
+-SetDspHighCutFrequency "SEGB1-RA2" 6000
+-SetDspHighCutNumberTaps "SEGB1-RA2" 256
+-SetInputInverted "SEGB1-RA2" True
+-SetNetComDataBufferingEnabled "SEGB1-RA2" True
+-SetNetComDataBufferSize "SEGB1-RA2" 3000
+-SetSpikeThreshold "SEGB1-RA2" 45
+-SetSpikeDetectionType "SEGB1-RA2" Threshold
+-SetSpikeSlope "SEGB1-RA2" 0 100 160
+-SetSpikeDualThresholding "SEGB1-RA2" False
+-SetSpikeRetriggerTime "SEGB1-RA2" 750
+-SetSpikeAlignmentPoint "SEGB1-RA2" 8
+-SetSubChannelEnabled "SEGB1-RA2" 0 True
+-SetWaveformFeature "SEGB1-RA2" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB1-RA2" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB1-RA2" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB1-RA2" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB1-RA2" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB1-RA2" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB1-RA2" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB1-RA2" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB1-RA3" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB1-RA3" True
+-SetChannelNumber "SEGB1-RA3" 34
+-SetInputRange "SEGB1-RA3" 400
+-SetSubSamplingInterleave "SEGB1-RA3" 1
+-SetDspLowCutFilterEnabled "SEGB1-RA3" True
+-SetDspLowCutFrequency "SEGB1-RA3" 600
+-SetDspLowCutNumberTaps "SEGB1-RA3" 256
+-SetDspHighCutFilterEnabled "SEGB1-RA3" True
+-SetDspHighCutFrequency "SEGB1-RA3" 6000
+-SetDspHighCutNumberTaps "SEGB1-RA3" 256
+-SetInputInverted "SEGB1-RA3" True
+-SetNetComDataBufferingEnabled "SEGB1-RA3" True
+-SetNetComDataBufferSize "SEGB1-RA3" 3000
+-SetSpikeThreshold "SEGB1-RA3" 45
+-SetSpikeDetectionType "SEGB1-RA3" Threshold
+-SetSpikeSlope "SEGB1-RA3" 0 100 160
+-SetSpikeDualThresholding "SEGB1-RA3" False
+-SetSpikeRetriggerTime "SEGB1-RA3" 750
+-SetSpikeAlignmentPoint "SEGB1-RA3" 8
+-SetSubChannelEnabled "SEGB1-RA3" 0 True
+-SetWaveformFeature "SEGB1-RA3" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB1-RA3" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB1-RA3" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB1-RA3" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB1-RA3" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB1-RA3" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB1-RA3" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB1-RA3" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB1-RA4" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB1-RA4" True
+-SetChannelNumber "SEGB1-RA4" 35
+-SetInputRange "SEGB1-RA4" 400
+-SetSubSamplingInterleave "SEGB1-RA4" 1
+-SetDspLowCutFilterEnabled "SEGB1-RA4" True
+-SetDspLowCutFrequency "SEGB1-RA4" 600
+-SetDspLowCutNumberTaps "SEGB1-RA4" 256
+-SetDspHighCutFilterEnabled "SEGB1-RA4" True
+-SetDspHighCutFrequency "SEGB1-RA4" 6000
+-SetDspHighCutNumberTaps "SEGB1-RA4" 256
+-SetInputInverted "SEGB1-RA4" True
+-SetNetComDataBufferingEnabled "SEGB1-RA4" True
+-SetNetComDataBufferSize "SEGB1-RA4" 3000
+-SetSpikeThreshold "SEGB1-RA4" 45
+-SetSpikeDetectionType "SEGB1-RA4" Threshold
+-SetSpikeSlope "SEGB1-RA4" 0 100 160
+-SetSpikeDualThresholding "SEGB1-RA4" False
+-SetSpikeRetriggerTime "SEGB1-RA4" 750
+-SetSpikeAlignmentPoint "SEGB1-RA4" 8
+-SetSubChannelEnabled "SEGB1-RA4" 0 True
+-SetWaveformFeature "SEGB1-RA4" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB1-RA4" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB1-RA4" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB1-RA4" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB1-RA4" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB1-RA4" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB1-RA4" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB1-RA4" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB1-RA5" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB1-RA5" True
+-SetChannelNumber "SEGB1-RA5" 36
+-SetInputRange "SEGB1-RA5" 400
+-SetSubSamplingInterleave "SEGB1-RA5" 1
+-SetDspLowCutFilterEnabled "SEGB1-RA5" True
+-SetDspLowCutFrequency "SEGB1-RA5" 600
+-SetDspLowCutNumberTaps "SEGB1-RA5" 256
+-SetDspHighCutFilterEnabled "SEGB1-RA5" True
+-SetDspHighCutFrequency "SEGB1-RA5" 6000
+-SetDspHighCutNumberTaps "SEGB1-RA5" 256
+-SetInputInverted "SEGB1-RA5" True
+-SetNetComDataBufferingEnabled "SEGB1-RA5" True
+-SetNetComDataBufferSize "SEGB1-RA5" 3000
+-SetSpikeThreshold "SEGB1-RA5" 45
+-SetSpikeDetectionType "SEGB1-RA5" Threshold
+-SetSpikeSlope "SEGB1-RA5" 0 100 160
+-SetSpikeDualThresholding "SEGB1-RA5" False
+-SetSpikeRetriggerTime "SEGB1-RA5" 750
+-SetSpikeAlignmentPoint "SEGB1-RA5" 8
+-SetSubChannelEnabled "SEGB1-RA5" 0 True
+-SetWaveformFeature "SEGB1-RA5" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB1-RA5" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB1-RA5" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB1-RA5" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB1-RA5" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB1-RA5" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB1-RA5" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB1-RA5" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB1-RA6" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB1-RA6" True
+-SetChannelNumber "SEGB1-RA6" 37
+-SetInputRange "SEGB1-RA6" 400
+-SetSubSamplingInterleave "SEGB1-RA6" 1
+-SetDspLowCutFilterEnabled "SEGB1-RA6" True
+-SetDspLowCutFrequency "SEGB1-RA6" 600
+-SetDspLowCutNumberTaps "SEGB1-RA6" 256
+-SetDspHighCutFilterEnabled "SEGB1-RA6" True
+-SetDspHighCutFrequency "SEGB1-RA6" 6000
+-SetDspHighCutNumberTaps "SEGB1-RA6" 256
+-SetInputInverted "SEGB1-RA6" True
+-SetNetComDataBufferingEnabled "SEGB1-RA6" True
+-SetNetComDataBufferSize "SEGB1-RA6" 3000
+-SetSpikeThreshold "SEGB1-RA6" 45
+-SetSpikeDetectionType "SEGB1-RA6" Threshold
+-SetSpikeSlope "SEGB1-RA6" 0 100 160
+-SetSpikeDualThresholding "SEGB1-RA6" False
+-SetSpikeRetriggerTime "SEGB1-RA6" 750
+-SetSpikeAlignmentPoint "SEGB1-RA6" 8
+-SetSubChannelEnabled "SEGB1-RA6" 0 True
+-SetWaveformFeature "SEGB1-RA6" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB1-RA6" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB1-RA6" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB1-RA6" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB1-RA6" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB1-RA6" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB1-RA6" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB1-RA6" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB1-RA7" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB1-RA7" True
+-SetChannelNumber "SEGB1-RA7" 38
+-SetInputRange "SEGB1-RA7" 400
+-SetSubSamplingInterleave "SEGB1-RA7" 1
+-SetDspLowCutFilterEnabled "SEGB1-RA7" True
+-SetDspLowCutFrequency "SEGB1-RA7" 600
+-SetDspLowCutNumberTaps "SEGB1-RA7" 256
+-SetDspHighCutFilterEnabled "SEGB1-RA7" True
+-SetDspHighCutFrequency "SEGB1-RA7" 6000
+-SetDspHighCutNumberTaps "SEGB1-RA7" 256
+-SetInputInverted "SEGB1-RA7" True
+-SetNetComDataBufferingEnabled "SEGB1-RA7" True
+-SetNetComDataBufferSize "SEGB1-RA7" 3000
+-SetSpikeThreshold "SEGB1-RA7" 45
+-SetSpikeDetectionType "SEGB1-RA7" Threshold
+-SetSpikeSlope "SEGB1-RA7" 0 100 160
+-SetSpikeDualThresholding "SEGB1-RA7" False
+-SetSpikeRetriggerTime "SEGB1-RA7" 750
+-SetSpikeAlignmentPoint "SEGB1-RA7" 8
+-SetSubChannelEnabled "SEGB1-RA7" 0 True
+-SetWaveformFeature "SEGB1-RA7" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB1-RA7" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB1-RA7" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB1-RA7" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB1-RA7" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB1-RA7" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB1-RA7" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB1-RA7" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB1-RA8" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB1-RA8" True
+-SetChannelNumber "SEGB1-RA8" 39
+-SetInputRange "SEGB1-RA8" 400
+-SetSubSamplingInterleave "SEGB1-RA8" 1
+-SetDspLowCutFilterEnabled "SEGB1-RA8" True
+-SetDspLowCutFrequency "SEGB1-RA8" 600
+-SetDspLowCutNumberTaps "SEGB1-RA8" 256
+-SetDspHighCutFilterEnabled "SEGB1-RA8" True
+-SetDspHighCutFrequency "SEGB1-RA8" 6000
+-SetDspHighCutNumberTaps "SEGB1-RA8" 256
+-SetInputInverted "SEGB1-RA8" True
+-SetNetComDataBufferingEnabled "SEGB1-RA8" True
+-SetNetComDataBufferSize "SEGB1-RA8" 3000
+-SetSpikeThreshold "SEGB1-RA8" 45
+-SetSpikeDetectionType "SEGB1-RA8" Threshold
+-SetSpikeSlope "SEGB1-RA8" 0 100 160
+-SetSpikeDualThresholding "SEGB1-RA8" False
+-SetSpikeRetriggerTime "SEGB1-RA8" 750
+-SetSpikeAlignmentPoint "SEGB1-RA8" 8
+-SetSubChannelEnabled "SEGB1-RA8" 0 True
+-SetWaveformFeature "SEGB1-RA8" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB1-RA8" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB1-RA8" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB1-RA8" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB1-RA8" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB1-RA8" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB1-RA8" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB1-RA8" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB2-LAC1" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB2-LAC1" True
+-SetChannelNumber "SEGB2-LAC1" 40
+-SetInputRange "SEGB2-LAC1" 400
+-SetSubSamplingInterleave "SEGB2-LAC1" 1
+-SetDspLowCutFilterEnabled "SEGB2-LAC1" True
+-SetDspLowCutFrequency "SEGB2-LAC1" 600
+-SetDspLowCutNumberTaps "SEGB2-LAC1" 256
+-SetDspHighCutFilterEnabled "SEGB2-LAC1" True
+-SetDspHighCutFrequency "SEGB2-LAC1" 6000
+-SetDspHighCutNumberTaps "SEGB2-LAC1" 256
+-SetInputInverted "SEGB2-LAC1" True
+-SetNetComDataBufferingEnabled "SEGB2-LAC1" True
+-SetNetComDataBufferSize "SEGB2-LAC1" 3000
+-SetSpikeThreshold "SEGB2-LAC1" 45
+-SetSpikeDetectionType "SEGB2-LAC1" Threshold
+-SetSpikeSlope "SEGB2-LAC1" 0 100 160
+-SetSpikeDualThresholding "SEGB2-LAC1" False
+-SetSpikeRetriggerTime "SEGB2-LAC1" 750
+-SetSpikeAlignmentPoint "SEGB2-LAC1" 8
+-SetSubChannelEnabled "SEGB2-LAC1" 0 True
+-SetWaveformFeature "SEGB2-LAC1" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC1" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC1" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC1" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC1" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB2-LAC1" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB2-LAC1" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB2-LAC1" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB2-LAC2" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB2-LAC2" True
+-SetChannelNumber "SEGB2-LAC2" 41
+-SetInputRange "SEGB2-LAC2" 400
+-SetSubSamplingInterleave "SEGB2-LAC2" 1
+-SetDspLowCutFilterEnabled "SEGB2-LAC2" True
+-SetDspLowCutFrequency "SEGB2-LAC2" 600
+-SetDspLowCutNumberTaps "SEGB2-LAC2" 256
+-SetDspHighCutFilterEnabled "SEGB2-LAC2" True
+-SetDspHighCutFrequency "SEGB2-LAC2" 6000
+-SetDspHighCutNumberTaps "SEGB2-LAC2" 256
+-SetInputInverted "SEGB2-LAC2" True
+-SetNetComDataBufferingEnabled "SEGB2-LAC2" True
+-SetNetComDataBufferSize "SEGB2-LAC2" 3000
+-SetSpikeThreshold "SEGB2-LAC2" 45
+-SetSpikeDetectionType "SEGB2-LAC2" Threshold
+-SetSpikeSlope "SEGB2-LAC2" 0 100 160
+-SetSpikeDualThresholding "SEGB2-LAC2" False
+-SetSpikeRetriggerTime "SEGB2-LAC2" 750
+-SetSpikeAlignmentPoint "SEGB2-LAC2" 8
+-SetSubChannelEnabled "SEGB2-LAC2" 0 True
+-SetWaveformFeature "SEGB2-LAC2" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC2" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC2" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC2" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC2" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB2-LAC2" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB2-LAC2" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB2-LAC2" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB2-LAC3" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB2-LAC3" True
+-SetChannelNumber "SEGB2-LAC3" 42
+-SetInputRange "SEGB2-LAC3" 400
+-SetSubSamplingInterleave "SEGB2-LAC3" 1
+-SetDspLowCutFilterEnabled "SEGB2-LAC3" True
+-SetDspLowCutFrequency "SEGB2-LAC3" 600
+-SetDspLowCutNumberTaps "SEGB2-LAC3" 256
+-SetDspHighCutFilterEnabled "SEGB2-LAC3" True
+-SetDspHighCutFrequency "SEGB2-LAC3" 6000
+-SetDspHighCutNumberTaps "SEGB2-LAC3" 256
+-SetInputInverted "SEGB2-LAC3" True
+-SetNetComDataBufferingEnabled "SEGB2-LAC3" True
+-SetNetComDataBufferSize "SEGB2-LAC3" 3000
+-SetSpikeThreshold "SEGB2-LAC3" 45
+-SetSpikeDetectionType "SEGB2-LAC3" Threshold
+-SetSpikeSlope "SEGB2-LAC3" 0 100 160
+-SetSpikeDualThresholding "SEGB2-LAC3" False
+-SetSpikeRetriggerTime "SEGB2-LAC3" 750
+-SetSpikeAlignmentPoint "SEGB2-LAC3" 8
+-SetSubChannelEnabled "SEGB2-LAC3" 0 True
+-SetWaveformFeature "SEGB2-LAC3" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC3" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC3" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC3" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC3" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB2-LAC3" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB2-LAC3" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB2-LAC3" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB2-LAC4" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB2-LAC4" True
+-SetChannelNumber "SEGB2-LAC4" 43
+-SetInputRange "SEGB2-LAC4" 400
+-SetSubSamplingInterleave "SEGB2-LAC4" 1
+-SetDspLowCutFilterEnabled "SEGB2-LAC4" True
+-SetDspLowCutFrequency "SEGB2-LAC4" 600
+-SetDspLowCutNumberTaps "SEGB2-LAC4" 256
+-SetDspHighCutFilterEnabled "SEGB2-LAC4" True
+-SetDspHighCutFrequency "SEGB2-LAC4" 6000
+-SetDspHighCutNumberTaps "SEGB2-LAC4" 256
+-SetInputInverted "SEGB2-LAC4" True
+-SetNetComDataBufferingEnabled "SEGB2-LAC4" True
+-SetNetComDataBufferSize "SEGB2-LAC4" 3000
+-SetSpikeThreshold "SEGB2-LAC4" 45
+-SetSpikeDetectionType "SEGB2-LAC4" Threshold
+-SetSpikeSlope "SEGB2-LAC4" 0 100 160
+-SetSpikeDualThresholding "SEGB2-LAC4" False
+-SetSpikeRetriggerTime "SEGB2-LAC4" 750
+-SetSpikeAlignmentPoint "SEGB2-LAC4" 8
+-SetSubChannelEnabled "SEGB2-LAC4" 0 True
+-SetWaveformFeature "SEGB2-LAC4" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC4" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC4" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC4" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC4" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB2-LAC4" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB2-LAC4" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB2-LAC4" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB2-LAC5" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB2-LAC5" True
+-SetChannelNumber "SEGB2-LAC5" 44
+-SetInputRange "SEGB2-LAC5" 400
+-SetSubSamplingInterleave "SEGB2-LAC5" 1
+-SetDspLowCutFilterEnabled "SEGB2-LAC5" True
+-SetDspLowCutFrequency "SEGB2-LAC5" 600
+-SetDspLowCutNumberTaps "SEGB2-LAC5" 256
+-SetDspHighCutFilterEnabled "SEGB2-LAC5" True
+-SetDspHighCutFrequency "SEGB2-LAC5" 6000
+-SetDspHighCutNumberTaps "SEGB2-LAC5" 256
+-SetInputInverted "SEGB2-LAC5" True
+-SetNetComDataBufferingEnabled "SEGB2-LAC5" True
+-SetNetComDataBufferSize "SEGB2-LAC5" 3000
+-SetSpikeThreshold "SEGB2-LAC5" 45
+-SetSpikeDetectionType "SEGB2-LAC5" Threshold
+-SetSpikeSlope "SEGB2-LAC5" 0 100 160
+-SetSpikeDualThresholding "SEGB2-LAC5" False
+-SetSpikeRetriggerTime "SEGB2-LAC5" 750
+-SetSpikeAlignmentPoint "SEGB2-LAC5" 8
+-SetSubChannelEnabled "SEGB2-LAC5" 0 True
+-SetWaveformFeature "SEGB2-LAC5" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC5" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC5" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC5" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC5" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB2-LAC5" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB2-LAC5" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB2-LAC5" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB2-LAC6" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB2-LAC6" True
+-SetChannelNumber "SEGB2-LAC6" 45
+-SetInputRange "SEGB2-LAC6" 400
+-SetSubSamplingInterleave "SEGB2-LAC6" 1
+-SetDspLowCutFilterEnabled "SEGB2-LAC6" True
+-SetDspLowCutFrequency "SEGB2-LAC6" 600
+-SetDspLowCutNumberTaps "SEGB2-LAC6" 256
+-SetDspHighCutFilterEnabled "SEGB2-LAC6" True
+-SetDspHighCutFrequency "SEGB2-LAC6" 6000
+-SetDspHighCutNumberTaps "SEGB2-LAC6" 256
+-SetInputInverted "SEGB2-LAC6" True
+-SetNetComDataBufferingEnabled "SEGB2-LAC6" True
+-SetNetComDataBufferSize "SEGB2-LAC6" 3000
+-SetSpikeThreshold "SEGB2-LAC6" 45
+-SetSpikeDetectionType "SEGB2-LAC6" Threshold
+-SetSpikeSlope "SEGB2-LAC6" 0 100 160
+-SetSpikeDualThresholding "SEGB2-LAC6" False
+-SetSpikeRetriggerTime "SEGB2-LAC6" 750
+-SetSpikeAlignmentPoint "SEGB2-LAC6" 8
+-SetSubChannelEnabled "SEGB2-LAC6" 0 True
+-SetWaveformFeature "SEGB2-LAC6" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC6" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC6" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC6" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC6" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB2-LAC6" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB2-LAC6" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB2-LAC6" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB2-LAC7" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB2-LAC7" True
+-SetChannelNumber "SEGB2-LAC7" 46
+-SetInputRange "SEGB2-LAC7" 400
+-SetSubSamplingInterleave "SEGB2-LAC7" 1
+-SetDspLowCutFilterEnabled "SEGB2-LAC7" True
+-SetDspLowCutFrequency "SEGB2-LAC7" 600
+-SetDspLowCutNumberTaps "SEGB2-LAC7" 256
+-SetDspHighCutFilterEnabled "SEGB2-LAC7" True
+-SetDspHighCutFrequency "SEGB2-LAC7" 6000
+-SetDspHighCutNumberTaps "SEGB2-LAC7" 256
+-SetInputInverted "SEGB2-LAC7" True
+-SetNetComDataBufferingEnabled "SEGB2-LAC7" True
+-SetNetComDataBufferSize "SEGB2-LAC7" 3000
+-SetSpikeThreshold "SEGB2-LAC7" 45
+-SetSpikeDetectionType "SEGB2-LAC7" Threshold
+-SetSpikeSlope "SEGB2-LAC7" 0 100 160
+-SetSpikeDualThresholding "SEGB2-LAC7" False
+-SetSpikeRetriggerTime "SEGB2-LAC7" 750
+-SetSpikeAlignmentPoint "SEGB2-LAC7" 8
+-SetSubChannelEnabled "SEGB2-LAC7" 0 True
+-SetWaveformFeature "SEGB2-LAC7" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC7" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC7" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC7" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC7" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB2-LAC7" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB2-LAC7" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB2-LAC7" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGB2-LAC8" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGB2-LAC8" True
+-SetChannelNumber "SEGB2-LAC8" 47
+-SetInputRange "SEGB2-LAC8" 400
+-SetSubSamplingInterleave "SEGB2-LAC8" 1
+-SetDspLowCutFilterEnabled "SEGB2-LAC8" True
+-SetDspLowCutFrequency "SEGB2-LAC8" 600
+-SetDspLowCutNumberTaps "SEGB2-LAC8" 256
+-SetDspHighCutFilterEnabled "SEGB2-LAC8" True
+-SetDspHighCutFrequency "SEGB2-LAC8" 6000
+-SetDspHighCutNumberTaps "SEGB2-LAC8" 256
+-SetInputInverted "SEGB2-LAC8" True
+-SetNetComDataBufferingEnabled "SEGB2-LAC8" True
+-SetNetComDataBufferSize "SEGB2-LAC8" 3000
+-SetSpikeThreshold "SEGB2-LAC8" 45
+-SetSpikeDetectionType "SEGB2-LAC8" Threshold
+-SetSpikeSlope "SEGB2-LAC8" 0 100 160
+-SetSpikeDualThresholding "SEGB2-LAC8" False
+-SetSpikeRetriggerTime "SEGB2-LAC8" 750
+-SetSpikeAlignmentPoint "SEGB2-LAC8" 8
+-SetSubChannelEnabled "SEGB2-LAC8" 0 True
+-SetWaveformFeature "SEGB2-LAC8" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC8" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC8" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC8" Height 3 0 0 31 1
+-SetWaveformFeature "SEGB2-LAC8" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGB2-LAC8" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGB2-LAC8" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGB2-LAC8" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC1-LMC1" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC1-LMC1" True
+-SetChannelNumber "SEGC1-LMC1" 64
+-SetInputRange "SEGC1-LMC1" 400
+-SetSubSamplingInterleave "SEGC1-LMC1" 1
+-SetDspLowCutFilterEnabled "SEGC1-LMC1" True
+-SetDspLowCutFrequency "SEGC1-LMC1" 600
+-SetDspLowCutNumberTaps "SEGC1-LMC1" 256
+-SetDspHighCutFilterEnabled "SEGC1-LMC1" True
+-SetDspHighCutFrequency "SEGC1-LMC1" 6000
+-SetDspHighCutNumberTaps "SEGC1-LMC1" 256
+-SetInputInverted "SEGC1-LMC1" True
+-SetNetComDataBufferingEnabled "SEGC1-LMC1" True
+-SetNetComDataBufferSize "SEGC1-LMC1" 3000
+-SetSpikeThreshold "SEGC1-LMC1" 45
+-SetSpikeDetectionType "SEGC1-LMC1" Threshold
+-SetSpikeSlope "SEGC1-LMC1" 0 100 160
+-SetSpikeDualThresholding "SEGC1-LMC1" False
+-SetSpikeRetriggerTime "SEGC1-LMC1" 750
+-SetSpikeAlignmentPoint "SEGC1-LMC1" 8
+-SetSubChannelEnabled "SEGC1-LMC1" 0 True
+-SetWaveformFeature "SEGC1-LMC1" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC1" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC1" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC1" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC1" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC1-LMC1" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC1-LMC1" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC1-LMC1" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC1-LMC2" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC1-LMC2" True
+-SetChannelNumber "SEGC1-LMC2" 65
+-SetInputRange "SEGC1-LMC2" 400
+-SetSubSamplingInterleave "SEGC1-LMC2" 1
+-SetDspLowCutFilterEnabled "SEGC1-LMC2" True
+-SetDspLowCutFrequency "SEGC1-LMC2" 600
+-SetDspLowCutNumberTaps "SEGC1-LMC2" 256
+-SetDspHighCutFilterEnabled "SEGC1-LMC2" True
+-SetDspHighCutFrequency "SEGC1-LMC2" 6000
+-SetDspHighCutNumberTaps "SEGC1-LMC2" 256
+-SetInputInverted "SEGC1-LMC2" True
+-SetNetComDataBufferingEnabled "SEGC1-LMC2" True
+-SetNetComDataBufferSize "SEGC1-LMC2" 3000
+-SetSpikeThreshold "SEGC1-LMC2" 45
+-SetSpikeDetectionType "SEGC1-LMC2" Threshold
+-SetSpikeSlope "SEGC1-LMC2" 0 100 160
+-SetSpikeDualThresholding "SEGC1-LMC2" False
+-SetSpikeRetriggerTime "SEGC1-LMC2" 750
+-SetSpikeAlignmentPoint "SEGC1-LMC2" 8
+-SetSubChannelEnabled "SEGC1-LMC2" 0 True
+-SetWaveformFeature "SEGC1-LMC2" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC2" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC2" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC2" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC2" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC1-LMC2" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC1-LMC2" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC1-LMC2" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC1-LMC3" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC1-LMC3" True
+-SetChannelNumber "SEGC1-LMC3" 66
+-SetInputRange "SEGC1-LMC3" 400
+-SetSubSamplingInterleave "SEGC1-LMC3" 1
+-SetDspLowCutFilterEnabled "SEGC1-LMC3" True
+-SetDspLowCutFrequency "SEGC1-LMC3" 600
+-SetDspLowCutNumberTaps "SEGC1-LMC3" 256
+-SetDspHighCutFilterEnabled "SEGC1-LMC3" True
+-SetDspHighCutFrequency "SEGC1-LMC3" 6000
+-SetDspHighCutNumberTaps "SEGC1-LMC3" 256
+-SetInputInverted "SEGC1-LMC3" True
+-SetNetComDataBufferingEnabled "SEGC1-LMC3" True
+-SetNetComDataBufferSize "SEGC1-LMC3" 3000
+-SetSpikeThreshold "SEGC1-LMC3" 45
+-SetSpikeDetectionType "SEGC1-LMC3" Threshold
+-SetSpikeSlope "SEGC1-LMC3" 0 100 160
+-SetSpikeDualThresholding "SEGC1-LMC3" False
+-SetSpikeRetriggerTime "SEGC1-LMC3" 750
+-SetSpikeAlignmentPoint "SEGC1-LMC3" 8
+-SetSubChannelEnabled "SEGC1-LMC3" 0 True
+-SetWaveformFeature "SEGC1-LMC3" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC3" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC3" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC3" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC3" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC1-LMC3" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC1-LMC3" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC1-LMC3" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC1-LMC4" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC1-LMC4" True
+-SetChannelNumber "SEGC1-LMC4" 67
+-SetInputRange "SEGC1-LMC4" 400
+-SetSubSamplingInterleave "SEGC1-LMC4" 1
+-SetDspLowCutFilterEnabled "SEGC1-LMC4" True
+-SetDspLowCutFrequency "SEGC1-LMC4" 600
+-SetDspLowCutNumberTaps "SEGC1-LMC4" 256
+-SetDspHighCutFilterEnabled "SEGC1-LMC4" True
+-SetDspHighCutFrequency "SEGC1-LMC4" 6000
+-SetDspHighCutNumberTaps "SEGC1-LMC4" 256
+-SetInputInverted "SEGC1-LMC4" True
+-SetNetComDataBufferingEnabled "SEGC1-LMC4" True
+-SetNetComDataBufferSize "SEGC1-LMC4" 3000
+-SetSpikeThreshold "SEGC1-LMC4" 45
+-SetSpikeDetectionType "SEGC1-LMC4" Threshold
+-SetSpikeSlope "SEGC1-LMC4" 0 100 160
+-SetSpikeDualThresholding "SEGC1-LMC4" False
+-SetSpikeRetriggerTime "SEGC1-LMC4" 750
+-SetSpikeAlignmentPoint "SEGC1-LMC4" 8
+-SetSubChannelEnabled "SEGC1-LMC4" 0 True
+-SetWaveformFeature "SEGC1-LMC4" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC4" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC4" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC4" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC4" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC1-LMC4" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC1-LMC4" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC1-LMC4" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC1-LMC5" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC1-LMC5" True
+-SetChannelNumber "SEGC1-LMC5" 68
+-SetInputRange "SEGC1-LMC5" 400
+-SetSubSamplingInterleave "SEGC1-LMC5" 1
+-SetDspLowCutFilterEnabled "SEGC1-LMC5" True
+-SetDspLowCutFrequency "SEGC1-LMC5" 600
+-SetDspLowCutNumberTaps "SEGC1-LMC5" 256
+-SetDspHighCutFilterEnabled "SEGC1-LMC5" True
+-SetDspHighCutFrequency "SEGC1-LMC5" 6000
+-SetDspHighCutNumberTaps "SEGC1-LMC5" 256
+-SetInputInverted "SEGC1-LMC5" True
+-SetNetComDataBufferingEnabled "SEGC1-LMC5" True
+-SetNetComDataBufferSize "SEGC1-LMC5" 3000
+-SetSpikeThreshold "SEGC1-LMC5" 45
+-SetSpikeDetectionType "SEGC1-LMC5" Threshold
+-SetSpikeSlope "SEGC1-LMC5" 0 100 160
+-SetSpikeDualThresholding "SEGC1-LMC5" False
+-SetSpikeRetriggerTime "SEGC1-LMC5" 750
+-SetSpikeAlignmentPoint "SEGC1-LMC5" 8
+-SetSubChannelEnabled "SEGC1-LMC5" 0 True
+-SetWaveformFeature "SEGC1-LMC5" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC5" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC5" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC5" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC5" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC1-LMC5" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC1-LMC5" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC1-LMC5" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC1-LMC6" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC1-LMC6" True
+-SetChannelNumber "SEGC1-LMC6" 69
+-SetInputRange "SEGC1-LMC6" 400
+-SetSubSamplingInterleave "SEGC1-LMC6" 1
+-SetDspLowCutFilterEnabled "SEGC1-LMC6" True
+-SetDspLowCutFrequency "SEGC1-LMC6" 600
+-SetDspLowCutNumberTaps "SEGC1-LMC6" 256
+-SetDspHighCutFilterEnabled "SEGC1-LMC6" True
+-SetDspHighCutFrequency "SEGC1-LMC6" 6000
+-SetDspHighCutNumberTaps "SEGC1-LMC6" 256
+-SetInputInverted "SEGC1-LMC6" True
+-SetNetComDataBufferingEnabled "SEGC1-LMC6" True
+-SetNetComDataBufferSize "SEGC1-LMC6" 3000
+-SetSpikeThreshold "SEGC1-LMC6" 45
+-SetSpikeDetectionType "SEGC1-LMC6" Threshold
+-SetSpikeSlope "SEGC1-LMC6" 0 100 160
+-SetSpikeDualThresholding "SEGC1-LMC6" False
+-SetSpikeRetriggerTime "SEGC1-LMC6" 750
+-SetSpikeAlignmentPoint "SEGC1-LMC6" 8
+-SetSubChannelEnabled "SEGC1-LMC6" 0 True
+-SetWaveformFeature "SEGC1-LMC6" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC6" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC6" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC6" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC6" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC1-LMC6" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC1-LMC6" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC1-LMC6" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC1-LMC7" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC1-LMC7" True
+-SetChannelNumber "SEGC1-LMC7" 70
+-SetInputRange "SEGC1-LMC7" 400
+-SetSubSamplingInterleave "SEGC1-LMC7" 1
+-SetDspLowCutFilterEnabled "SEGC1-LMC7" True
+-SetDspLowCutFrequency "SEGC1-LMC7" 600
+-SetDspLowCutNumberTaps "SEGC1-LMC7" 256
+-SetDspHighCutFilterEnabled "SEGC1-LMC7" True
+-SetDspHighCutFrequency "SEGC1-LMC7" 6000
+-SetDspHighCutNumberTaps "SEGC1-LMC7" 256
+-SetInputInverted "SEGC1-LMC7" True
+-SetNetComDataBufferingEnabled "SEGC1-LMC7" True
+-SetNetComDataBufferSize "SEGC1-LMC7" 3000
+-SetSpikeThreshold "SEGC1-LMC7" 45
+-SetSpikeDetectionType "SEGC1-LMC7" Threshold
+-SetSpikeSlope "SEGC1-LMC7" 0 100 160
+-SetSpikeDualThresholding "SEGC1-LMC7" False
+-SetSpikeRetriggerTime "SEGC1-LMC7" 750
+-SetSpikeAlignmentPoint "SEGC1-LMC7" 8
+-SetSubChannelEnabled "SEGC1-LMC7" 0 True
+-SetWaveformFeature "SEGC1-LMC7" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC7" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC7" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC7" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC7" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC1-LMC7" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC1-LMC7" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC1-LMC7" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC1-LMC8" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC1-LMC8" True
+-SetChannelNumber "SEGC1-LMC8" 71
+-SetInputRange "SEGC1-LMC8" 400
+-SetSubSamplingInterleave "SEGC1-LMC8" 1
+-SetDspLowCutFilterEnabled "SEGC1-LMC8" True
+-SetDspLowCutFrequency "SEGC1-LMC8" 600
+-SetDspLowCutNumberTaps "SEGC1-LMC8" 256
+-SetDspHighCutFilterEnabled "SEGC1-LMC8" True
+-SetDspHighCutFrequency "SEGC1-LMC8" 6000
+-SetDspHighCutNumberTaps "SEGC1-LMC8" 256
+-SetInputInverted "SEGC1-LMC8" True
+-SetNetComDataBufferingEnabled "SEGC1-LMC8" True
+-SetNetComDataBufferSize "SEGC1-LMC8" 3000
+-SetSpikeThreshold "SEGC1-LMC8" 45
+-SetSpikeDetectionType "SEGC1-LMC8" Threshold
+-SetSpikeSlope "SEGC1-LMC8" 0 100 160
+-SetSpikeDualThresholding "SEGC1-LMC8" False
+-SetSpikeRetriggerTime "SEGC1-LMC8" 750
+-SetSpikeAlignmentPoint "SEGC1-LMC8" 8
+-SetSubChannelEnabled "SEGC1-LMC8" 0 True
+-SetWaveformFeature "SEGC1-LMC8" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC8" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC8" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC8" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC1-LMC8" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC1-LMC8" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC1-LMC8" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC1-LMC8" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC2-LOF1" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC2-LOF1" True
+-SetChannelNumber "SEGC2-LOF1" 72
+-SetInputRange "SEGC2-LOF1" 400
+-SetSubSamplingInterleave "SEGC2-LOF1" 1
+-SetDspLowCutFilterEnabled "SEGC2-LOF1" True
+-SetDspLowCutFrequency "SEGC2-LOF1" 600
+-SetDspLowCutNumberTaps "SEGC2-LOF1" 256
+-SetDspHighCutFilterEnabled "SEGC2-LOF1" True
+-SetDspHighCutFrequency "SEGC2-LOF1" 6000
+-SetDspHighCutNumberTaps "SEGC2-LOF1" 256
+-SetInputInverted "SEGC2-LOF1" True
+-SetNetComDataBufferingEnabled "SEGC2-LOF1" True
+-SetNetComDataBufferSize "SEGC2-LOF1" 3000
+-SetSpikeThreshold "SEGC2-LOF1" 45
+-SetSpikeDetectionType "SEGC2-LOF1" Threshold
+-SetSpikeSlope "SEGC2-LOF1" 0 100 160
+-SetSpikeDualThresholding "SEGC2-LOF1" False
+-SetSpikeRetriggerTime "SEGC2-LOF1" 750
+-SetSpikeAlignmentPoint "SEGC2-LOF1" 8
+-SetSubChannelEnabled "SEGC2-LOF1" 0 True
+-SetWaveformFeature "SEGC2-LOF1" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF1" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF1" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF1" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF1" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC2-LOF1" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC2-LOF1" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC2-LOF1" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC2-LOF2" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC2-LOF2" True
+-SetChannelNumber "SEGC2-LOF2" 73
+-SetInputRange "SEGC2-LOF2" 400
+-SetSubSamplingInterleave "SEGC2-LOF2" 1
+-SetDspLowCutFilterEnabled "SEGC2-LOF2" True
+-SetDspLowCutFrequency "SEGC2-LOF2" 600
+-SetDspLowCutNumberTaps "SEGC2-LOF2" 256
+-SetDspHighCutFilterEnabled "SEGC2-LOF2" True
+-SetDspHighCutFrequency "SEGC2-LOF2" 6000
+-SetDspHighCutNumberTaps "SEGC2-LOF2" 256
+-SetInputInverted "SEGC2-LOF2" True
+-SetNetComDataBufferingEnabled "SEGC2-LOF2" True
+-SetNetComDataBufferSize "SEGC2-LOF2" 3000
+-SetSpikeThreshold "SEGC2-LOF2" 45
+-SetSpikeDetectionType "SEGC2-LOF2" Threshold
+-SetSpikeSlope "SEGC2-LOF2" 0 100 160
+-SetSpikeDualThresholding "SEGC2-LOF2" False
+-SetSpikeRetriggerTime "SEGC2-LOF2" 750
+-SetSpikeAlignmentPoint "SEGC2-LOF2" 8
+-SetSubChannelEnabled "SEGC2-LOF2" 0 True
+-SetWaveformFeature "SEGC2-LOF2" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF2" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF2" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF2" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF2" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC2-LOF2" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC2-LOF2" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC2-LOF2" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC2-LOF3" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC2-LOF3" True
+-SetChannelNumber "SEGC2-LOF3" 74
+-SetInputRange "SEGC2-LOF3" 400
+-SetSubSamplingInterleave "SEGC2-LOF3" 1
+-SetDspLowCutFilterEnabled "SEGC2-LOF3" True
+-SetDspLowCutFrequency "SEGC2-LOF3" 600
+-SetDspLowCutNumberTaps "SEGC2-LOF3" 256
+-SetDspHighCutFilterEnabled "SEGC2-LOF3" True
+-SetDspHighCutFrequency "SEGC2-LOF3" 6000
+-SetDspHighCutNumberTaps "SEGC2-LOF3" 256
+-SetInputInverted "SEGC2-LOF3" True
+-SetNetComDataBufferingEnabled "SEGC2-LOF3" True
+-SetNetComDataBufferSize "SEGC2-LOF3" 3000
+-SetSpikeThreshold "SEGC2-LOF3" 45
+-SetSpikeDetectionType "SEGC2-LOF3" Threshold
+-SetSpikeSlope "SEGC2-LOF3" 0 100 160
+-SetSpikeDualThresholding "SEGC2-LOF3" False
+-SetSpikeRetriggerTime "SEGC2-LOF3" 750
+-SetSpikeAlignmentPoint "SEGC2-LOF3" 8
+-SetSubChannelEnabled "SEGC2-LOF3" 0 True
+-SetWaveformFeature "SEGC2-LOF3" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF3" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF3" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF3" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF3" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC2-LOF3" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC2-LOF3" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC2-LOF3" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC2-LOF4" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC2-LOF4" True
+-SetChannelNumber "SEGC2-LOF4" 75
+-SetInputRange "SEGC2-LOF4" 400
+-SetSubSamplingInterleave "SEGC2-LOF4" 1
+-SetDspLowCutFilterEnabled "SEGC2-LOF4" True
+-SetDspLowCutFrequency "SEGC2-LOF4" 600
+-SetDspLowCutNumberTaps "SEGC2-LOF4" 256
+-SetDspHighCutFilterEnabled "SEGC2-LOF4" True
+-SetDspHighCutFrequency "SEGC2-LOF4" 6000
+-SetDspHighCutNumberTaps "SEGC2-LOF4" 256
+-SetInputInverted "SEGC2-LOF4" True
+-SetNetComDataBufferingEnabled "SEGC2-LOF4" True
+-SetNetComDataBufferSize "SEGC2-LOF4" 3000
+-SetSpikeThreshold "SEGC2-LOF4" 45
+-SetSpikeDetectionType "SEGC2-LOF4" Threshold
+-SetSpikeSlope "SEGC2-LOF4" 0 100 160
+-SetSpikeDualThresholding "SEGC2-LOF4" False
+-SetSpikeRetriggerTime "SEGC2-LOF4" 750
+-SetSpikeAlignmentPoint "SEGC2-LOF4" 8
+-SetSubChannelEnabled "SEGC2-LOF4" 0 True
+-SetWaveformFeature "SEGC2-LOF4" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF4" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF4" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF4" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF4" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC2-LOF4" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC2-LOF4" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC2-LOF4" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC2-LOF5" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC2-LOF5" True
+-SetChannelNumber "SEGC2-LOF5" 76
+-SetInputRange "SEGC2-LOF5" 400
+-SetSubSamplingInterleave "SEGC2-LOF5" 1
+-SetDspLowCutFilterEnabled "SEGC2-LOF5" True
+-SetDspLowCutFrequency "SEGC2-LOF5" 600
+-SetDspLowCutNumberTaps "SEGC2-LOF5" 256
+-SetDspHighCutFilterEnabled "SEGC2-LOF5" True
+-SetDspHighCutFrequency "SEGC2-LOF5" 6000
+-SetDspHighCutNumberTaps "SEGC2-LOF5" 256
+-SetInputInverted "SEGC2-LOF5" True
+-SetNetComDataBufferingEnabled "SEGC2-LOF5" True
+-SetNetComDataBufferSize "SEGC2-LOF5" 3000
+-SetSpikeThreshold "SEGC2-LOF5" 45
+-SetSpikeDetectionType "SEGC2-LOF5" Threshold
+-SetSpikeSlope "SEGC2-LOF5" 0 100 160
+-SetSpikeDualThresholding "SEGC2-LOF5" False
+-SetSpikeRetriggerTime "SEGC2-LOF5" 750
+-SetSpikeAlignmentPoint "SEGC2-LOF5" 8
+-SetSubChannelEnabled "SEGC2-LOF5" 0 True
+-SetWaveformFeature "SEGC2-LOF5" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF5" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF5" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF5" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF5" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC2-LOF5" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC2-LOF5" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC2-LOF5" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC2-LOF6" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC2-LOF6" True
+-SetChannelNumber "SEGC2-LOF6" 77
+-SetInputRange "SEGC2-LOF6" 400
+-SetSubSamplingInterleave "SEGC2-LOF6" 1
+-SetDspLowCutFilterEnabled "SEGC2-LOF6" True
+-SetDspLowCutFrequency "SEGC2-LOF6" 600
+-SetDspLowCutNumberTaps "SEGC2-LOF6" 256
+-SetDspHighCutFilterEnabled "SEGC2-LOF6" True
+-SetDspHighCutFrequency "SEGC2-LOF6" 6000
+-SetDspHighCutNumberTaps "SEGC2-LOF6" 256
+-SetInputInverted "SEGC2-LOF6" True
+-SetNetComDataBufferingEnabled "SEGC2-LOF6" True
+-SetNetComDataBufferSize "SEGC2-LOF6" 3000
+-SetSpikeThreshold "SEGC2-LOF6" 45
+-SetSpikeDetectionType "SEGC2-LOF6" Threshold
+-SetSpikeSlope "SEGC2-LOF6" 0 100 160
+-SetSpikeDualThresholding "SEGC2-LOF6" False
+-SetSpikeRetriggerTime "SEGC2-LOF6" 750
+-SetSpikeAlignmentPoint "SEGC2-LOF6" 8
+-SetSubChannelEnabled "SEGC2-LOF6" 0 True
+-SetWaveformFeature "SEGC2-LOF6" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF6" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF6" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF6" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF6" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC2-LOF6" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC2-LOF6" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC2-LOF6" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC2-LOF7" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC2-LOF7" True
+-SetChannelNumber "SEGC2-LOF7" 78
+-SetInputRange "SEGC2-LOF7" 400
+-SetSubSamplingInterleave "SEGC2-LOF7" 1
+-SetDspLowCutFilterEnabled "SEGC2-LOF7" True
+-SetDspLowCutFrequency "SEGC2-LOF7" 600
+-SetDspLowCutNumberTaps "SEGC2-LOF7" 256
+-SetDspHighCutFilterEnabled "SEGC2-LOF7" True
+-SetDspHighCutFrequency "SEGC2-LOF7" 6000
+-SetDspHighCutNumberTaps "SEGC2-LOF7" 256
+-SetInputInverted "SEGC2-LOF7" True
+-SetNetComDataBufferingEnabled "SEGC2-LOF7" True
+-SetNetComDataBufferSize "SEGC2-LOF7" 3000
+-SetSpikeThreshold "SEGC2-LOF7" 45
+-SetSpikeDetectionType "SEGC2-LOF7" Threshold
+-SetSpikeSlope "SEGC2-LOF7" 0 100 160
+-SetSpikeDualThresholding "SEGC2-LOF7" False
+-SetSpikeRetriggerTime "SEGC2-LOF7" 750
+-SetSpikeAlignmentPoint "SEGC2-LOF7" 8
+-SetSubChannelEnabled "SEGC2-LOF7" 0 True
+-SetWaveformFeature "SEGC2-LOF7" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF7" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF7" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF7" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF7" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC2-LOF7" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC2-LOF7" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC2-LOF7" NthSample 7 0 0 31 1 28
+
+-CreateSpikeAcqEnt "SEGC2-LOF8" "AcqSystem1" 1
+-SetAcqEntProcessingEnabled "SEGC2-LOF8" True
+-SetChannelNumber "SEGC2-LOF8" 79
+-SetInputRange "SEGC2-LOF8" 400
+-SetSubSamplingInterleave "SEGC2-LOF8" 1
+-SetDspLowCutFilterEnabled "SEGC2-LOF8" True
+-SetDspLowCutFrequency "SEGC2-LOF8" 600
+-SetDspLowCutNumberTaps "SEGC2-LOF8" 256
+-SetDspHighCutFilterEnabled "SEGC2-LOF8" True
+-SetDspHighCutFrequency "SEGC2-LOF8" 6000
+-SetDspHighCutNumberTaps "SEGC2-LOF8" 256
+-SetInputInverted "SEGC2-LOF8" True
+-SetNetComDataBufferingEnabled "SEGC2-LOF8" True
+-SetNetComDataBufferSize "SEGC2-LOF8" 3000
+-SetSpikeThreshold "SEGC2-LOF8" 45
+-SetSpikeDetectionType "SEGC2-LOF8" Threshold
+-SetSpikeSlope "SEGC2-LOF8" 0 100 160
+-SetSpikeDualThresholding "SEGC2-LOF8" False
+-SetSpikeRetriggerTime "SEGC2-LOF8" 750
+-SetSpikeAlignmentPoint "SEGC2-LOF8" 8
+-SetSubChannelEnabled "SEGC2-LOF8" 0 True
+-SetWaveformFeature "SEGC2-LOF8" Peak 0 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF8" Valley 1 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF8" Energy 2 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF8" Height 3 0 0 31 1
+-SetWaveformFeature "SEGC2-LOF8" NthSample 4 0 0 31 1 4
+-SetWaveformFeature "SEGC2-LOF8" NthSample 5 0 0 31 1 16
+-SetWaveformFeature "SEGC2-LOF8" NthSample 6 0 0 31 1 24
+-SetWaveformFeature "SEGC2-LOF8" NthSample 7 0 0 31 1 28
+
+#Main Window Setup
+-SetDialogPosition Main -16 0
+-SetDialogVisible Main True
+
+#System Status Dialog Setup
+-SetSystemStatusShowDetails True
+-SetDialogPosition Status 5 55
+-SetSystemStatusMessageFilter Fatal on
+-SetSystemStatusMessageFilter Error on
+-SetSystemStatusMessageFilter Warning on
+-SetSystemStatusMessageFilter Notice off
+-SetSystemStatusMessageFilter Data off
+-SetDialogVisible Status True
+
+#Properties Display Setup
+-SetDialogPosition Properties 1374 790
+-SetDialogVisible Properties True
+
+#Event Dialog Setup
+-SetDialogPosition Events 0 42
+-SetDialogVisible Events True
+-SetEventStringImmediateMode Off
+-SetEventStringSingleKeyMode Off
+-SetEventDisplayTTLValueFormat Binary
+
+# Plot Window Setup for "Micro Window"
+-CreatePlotWindow Time "Micro Window"
+-SetPlotWindowSpreadType "Micro Window" Spread
+-SetPlotWindowPlotType "Micro Window" Sweep
+-SetPlotWindowTimeframe "Micro Window" 5000
+-SetPlotWindowHistoryTimeframe "Micro Window" 30
+-SetPlotWindowShowGridLines "Micro Window" True
+-SetPlotWindowBackgroundColor "Micro Window" 255 255 255
+-SetPlotWindowPosition "Micro Window" 14 807 1449 746
+-SetPlotWindowOverlay "Micro Window" False
+-SetPlotWindowShowTitleBar "Micro Window" True
+# Plot addition and setup for "Micro Window"
+
+-AddPlot "Micro Window" "GA1-LA1"
+-SetPlotEnabled "Micro Window" "GA1-LA1" True
+-SetTimePlotZoomFactor "Micro Window" "GA1-LA1" 32
+-SetPlotWaveformColor "Micro Window" "GA1-LA1" 25 25 112
+
+-AddPlot "Micro Window" "GA1-LA2"
+-SetPlotEnabled "Micro Window" "GA1-LA2" True
+-SetTimePlotZoomFactor "Micro Window" "GA1-LA2" 32
+-SetPlotWaveformColor "Micro Window" "GA1-LA2" 25 25 112
+
+-AddPlot "Micro Window" "GA1-LA3"
+-SetPlotEnabled "Micro Window" "GA1-LA3" True
+-SetTimePlotZoomFactor "Micro Window" "GA1-LA3" 32
+-SetPlotWaveformColor "Micro Window" "GA1-LA3" 25 25 112
+
+-AddPlot "Micro Window" "GA1-LA4"
+-SetPlotEnabled "Micro Window" "GA1-LA4" True
+-SetTimePlotZoomFactor "Micro Window" "GA1-LA4" 32
+-SetPlotWaveformColor "Micro Window" "GA1-LA4" 25 25 112
+
+-AddPlot "Micro Window" "GA1-LA5"
+-SetPlotEnabled "Micro Window" "GA1-LA5" True
+-SetTimePlotZoomFactor "Micro Window" "GA1-LA5" 32
+-SetPlotWaveformColor "Micro Window" "GA1-LA5" 25 25 112
+
+-AddPlot "Micro Window" "GA1-LA6"
+-SetPlotEnabled "Micro Window" "GA1-LA6" True
+-SetTimePlotZoomFactor "Micro Window" "GA1-LA6" 32
+-SetPlotWaveformColor "Micro Window" "GA1-LA6" 25 25 112
+
+-AddPlot "Micro Window" "GA1-LA7"
+-SetPlotEnabled "Micro Window" "GA1-LA7" True
+-SetTimePlotZoomFactor "Micro Window" "GA1-LA7" 32
+-SetPlotWaveformColor "Micro Window" "GA1-LA7" 25 25 112
+
+-AddPlot "Micro Window" "GA1-LA8"
+-SetPlotEnabled "Micro Window" "GA1-LA8" True
+-SetTimePlotZoomFactor "Micro Window" "GA1-LA8" 32
+-SetPlotWaveformColor "Micro Window" "GA1-LA8" 25 25 112
+
+-AddPlot "Micro Window" "GA2-LAC1"
+-SetPlotEnabled "Micro Window" "GA2-LAC1" True
+-SetTimePlotZoomFactor "Micro Window" "GA2-LAC1" 32
+-SetPlotWaveformColor "Micro Window" "GA2-LAC1" 25 25 112
+
+-AddPlot "Micro Window" "GA2-LAC2"
+-SetPlotEnabled "Micro Window" "GA2-LAC2" True
+-SetTimePlotZoomFactor "Micro Window" "GA2-LAC2" 32
+-SetPlotWaveformColor "Micro Window" "GA2-LAC2" 25 25 112
+
+-AddPlot "Micro Window" "GA2-LAC3"
+-SetPlotEnabled "Micro Window" "GA2-LAC3" True
+-SetTimePlotZoomFactor "Micro Window" "GA2-LAC3" 32
+-SetPlotWaveformColor "Micro Window" "GA2-LAC3" 25 25 112
+
+-AddPlot "Micro Window" "GA2-LAC4"
+-SetPlotEnabled "Micro Window" "GA2-LAC4" True
+-SetTimePlotZoomFactor "Micro Window" "GA2-LAC4" 32
+-SetPlotWaveformColor "Micro Window" "GA2-LAC4" 25 25 112
+
+-AddPlot "Micro Window" "GA2-LAC5"
+-SetPlotEnabled "Micro Window" "GA2-LAC5" True
+-SetTimePlotZoomFactor "Micro Window" "GA2-LAC5" 32
+-SetPlotWaveformColor "Micro Window" "GA2-LAC5" 25 25 112
+
+-AddPlot "Micro Window" "GA2-LAC6"
+-SetPlotEnabled "Micro Window" "GA2-LAC6" True
+-SetTimePlotZoomFactor "Micro Window" "GA2-LAC6" 32
+-SetPlotWaveformColor "Micro Window" "GA2-LAC6" 25 25 112
+
+-AddPlot "Micro Window" "GA2-LAC7"
+-SetPlotEnabled "Micro Window" "GA2-LAC7" True
+-SetTimePlotZoomFactor "Micro Window" "GA2-LAC7" 32
+-SetPlotWaveformColor "Micro Window" "GA2-LAC7" 25 25 112
+
+-AddPlot "Micro Window" "GA2-LAC8"
+-SetPlotEnabled "Micro Window" "GA2-LAC8" True
+-SetTimePlotZoomFactor "Micro Window" "GA2-LAC8" 32
+-SetPlotWaveformColor "Micro Window" "GA2-LAC8" 25 25 112
+
+-AddPlot "Micro Window" "GA3-LACd1"
+-SetPlotEnabled "Micro Window" "GA3-LACd1" True
+-SetTimePlotZoomFactor "Micro Window" "GA3-LACd1" 32
+-SetPlotWaveformColor "Micro Window" "GA3-LACd1" 25 25 112
+
+-AddPlot "Micro Window" "GA3-LACd2"
+-SetPlotEnabled "Micro Window" "GA3-LACd2" True
+-SetTimePlotZoomFactor "Micro Window" "GA3-LACd2" 32
+-SetPlotWaveformColor "Micro Window" "GA3-LACd2" 25 25 112
+
+-AddPlot "Micro Window" "GA3-LACd3"
+-SetPlotEnabled "Micro Window" "GA3-LACd3" True
+-SetTimePlotZoomFactor "Micro Window" "GA3-LACd3" 32
+-SetPlotWaveformColor "Micro Window" "GA3-LACd3" 25 25 112
+
+-AddPlot "Micro Window" "GA3-LACd4"
+-SetPlotEnabled "Micro Window" "GA3-LACd4" True
+-SetTimePlotZoomFactor "Micro Window" "GA3-LACd4" 32
+-SetPlotWaveformColor "Micro Window" "GA3-LACd4" 25 25 112
+
+-AddPlot "Micro Window" "GA3-LACd5"
+-SetPlotEnabled "Micro Window" "GA3-LACd5" True
+-SetTimePlotZoomFactor "Micro Window" "GA3-LACd5" 32
+-SetPlotWaveformColor "Micro Window" "GA3-LACd5" 25 25 112
+
+-AddPlot "Micro Window" "GA3-LACd6"
+-SetPlotEnabled "Micro Window" "GA3-LACd6" True
+-SetTimePlotZoomFactor "Micro Window" "GA3-LACd6" 32
+-SetPlotWaveformColor "Micro Window" "GA3-LACd6" 25 25 112
+
+-AddPlot "Micro Window" "GA3-LACd7"
+-SetPlotEnabled "Micro Window" "GA3-LACd7" True
+-SetTimePlotZoomFactor "Micro Window" "GA3-LACd7" 32
+-SetPlotWaveformColor "Micro Window" "GA3-LACd7" 25 25 112
+
+-AddPlot "Micro Window" "GA3-LACd8"
+-SetPlotEnabled "Micro Window" "GA3-LACd8" True
+-SetTimePlotZoomFactor "Micro Window" "GA3-LACd8" 32
+-SetPlotWaveformColor "Micro Window" "GA3-LACd8" 25 25 112
+
+-AddPlot "Micro Window" "GB1-RA1"
+-SetPlotEnabled "Micro Window" "GB1-RA1" True
+-SetTimePlotZoomFactor "Micro Window" "GB1-RA1" 32
+-SetPlotWaveformColor "Micro Window" "GB1-RA1" 25 25 112
+
+-AddPlot "Micro Window" "GB1-RA2"
+-SetPlotEnabled "Micro Window" "GB1-RA2" True
+-SetTimePlotZoomFactor "Micro Window" "GB1-RA2" 32
+-SetPlotWaveformColor "Micro Window" "GB1-RA2" 25 25 112
+
+-AddPlot "Micro Window" "GB1-RA3"
+-SetPlotEnabled "Micro Window" "GB1-RA3" True
+-SetTimePlotZoomFactor "Micro Window" "GB1-RA3" 32
+-SetPlotWaveformColor "Micro Window" "GB1-RA3" 25 25 112
+
+-AddPlot "Micro Window" "GB1-RA4"
+-SetPlotEnabled "Micro Window" "GB1-RA4" True
+-SetTimePlotZoomFactor "Micro Window" "GB1-RA4" 32
+-SetPlotWaveformColor "Micro Window" "GB1-RA4" 25 25 112
+
+-AddPlot "Micro Window" "GB1-RA5"
+-SetPlotEnabled "Micro Window" "GB1-RA5" True
+-SetTimePlotZoomFactor "Micro Window" "GB1-RA5" 32
+-SetPlotWaveformColor "Micro Window" "GB1-RA5" 25 25 112
+
+-AddPlot "Micro Window" "GB1-RA6"
+-SetPlotEnabled "Micro Window" "GB1-RA6" True
+-SetTimePlotZoomFactor "Micro Window" "GB1-RA6" 32
+-SetPlotWaveformColor "Micro Window" "GB1-RA6" 25 25 112
+
+-AddPlot "Micro Window" "GB1-RA7"
+-SetPlotEnabled "Micro Window" "GB1-RA7" True
+-SetTimePlotZoomFactor "Micro Window" "GB1-RA7" 32
+-SetPlotWaveformColor "Micro Window" "GB1-RA7" 25 25 112
+
+-AddPlot "Micro Window" "GB1-RA8"
+-SetPlotEnabled "Micro Window" "GB1-RA8" True
+-SetTimePlotZoomFactor "Micro Window" "GB1-RA8" 32
+-SetPlotWaveformColor "Micro Window" "GB1-RA8" 25 25 112
+
+-AddPlot "Micro Window" "GB2-LAC1"
+-SetPlotEnabled "Micro Window" "GB2-LAC1" True
+-SetTimePlotZoomFactor "Micro Window" "GB2-LAC1" 32
+-SetPlotWaveformColor "Micro Window" "GB2-LAC1" 25 25 112
+
+-AddPlot "Micro Window" "GB2-LAC2"
+-SetPlotEnabled "Micro Window" "GB2-LAC2" True
+-SetTimePlotZoomFactor "Micro Window" "GB2-LAC2" 32
+-SetPlotWaveformColor "Micro Window" "GB2-LAC2" 25 25 112
+
+-AddPlot "Micro Window" "GB2-LAC3"
+-SetPlotEnabled "Micro Window" "GB2-LAC3" True
+-SetTimePlotZoomFactor "Micro Window" "GB2-LAC3" 32
+-SetPlotWaveformColor "Micro Window" "GB2-LAC3" 25 25 112
+
+-AddPlot "Micro Window" "GB2-LAC4"
+-SetPlotEnabled "Micro Window" "GB2-LAC4" True
+-SetTimePlotZoomFactor "Micro Window" "GB2-LAC4" 32
+-SetPlotWaveformColor "Micro Window" "GB2-LAC4" 25 25 112
+
+-AddPlot "Micro Window" "GB2-LAC5"
+-SetPlotEnabled "Micro Window" "GB2-LAC5" True
+-SetTimePlotZoomFactor "Micro Window" "GB2-LAC5" 32
+-SetPlotWaveformColor "Micro Window" "GB2-LAC5" 25 25 112
+
+-AddPlot "Micro Window" "GB2-LAC6"
+-SetPlotEnabled "Micro Window" "GB2-LAC6" True
+-SetTimePlotZoomFactor "Micro Window" "GB2-LAC6" 32
+-SetPlotWaveformColor "Micro Window" "GB2-LAC6" 25 25 112
+
+-AddPlot "Micro Window" "GB2-LAC7"
+-SetPlotEnabled "Micro Window" "GB2-LAC7" True
+-SetTimePlotZoomFactor "Micro Window" "GB2-LAC7" 32
+-SetPlotWaveformColor "Micro Window" "GB2-LAC7" 25 25 112
+
+-AddPlot "Micro Window" "GB2-LAC8"
+-SetPlotEnabled "Micro Window" "GB2-LAC8" True
+-SetTimePlotZoomFactor "Micro Window" "GB2-LAC8" 32
+-SetPlotWaveformColor "Micro Window" "GB2-LAC8" 25 25 112
+
+-AddPlot "Micro Window" "GC1-LMC1"
+-SetPlotEnabled "Micro Window" "GC1-LMC1" True
+-SetTimePlotZoomFactor "Micro Window" "GC1-LMC1" 32
+-SetPlotWaveformColor "Micro Window" "GC1-LMC1" 25 25 112
+
+-AddPlot "Micro Window" "GC1-LMC2"
+-SetPlotEnabled "Micro Window" "GC1-LMC2" True
+-SetTimePlotZoomFactor "Micro Window" "GC1-LMC2" 32
+-SetPlotWaveformColor "Micro Window" "GC1-LMC2" 25 25 112
+
+-AddPlot "Micro Window" "GC1-LMC3"
+-SetPlotEnabled "Micro Window" "GC1-LMC3" True
+-SetTimePlotZoomFactor "Micro Window" "GC1-LMC3" 32
+-SetPlotWaveformColor "Micro Window" "GC1-LMC3" 25 25 112
+
+-AddPlot "Micro Window" "GC1-LMC4"
+-SetPlotEnabled "Micro Window" "GC1-LMC4" True
+-SetTimePlotZoomFactor "Micro Window" "GC1-LMC4" 32
+-SetPlotWaveformColor "Micro Window" "GC1-LMC4" 25 25 112
+
+-AddPlot "Micro Window" "GC1-LMC5"
+-SetPlotEnabled "Micro Window" "GC1-LMC5" True
+-SetTimePlotZoomFactor "Micro Window" "GC1-LMC5" 32
+-SetPlotWaveformColor "Micro Window" "GC1-LMC5" 25 25 112
+
+-AddPlot "Micro Window" "GC1-LMC6"
+-SetPlotEnabled "Micro Window" "GC1-LMC6" True
+-SetTimePlotZoomFactor "Micro Window" "GC1-LMC6" 32
+-SetPlotWaveformColor "Micro Window" "GC1-LMC6" 25 25 112
+
+-AddPlot "Micro Window" "GC1-LMC7"
+-SetPlotEnabled "Micro Window" "GC1-LMC7" True
+-SetTimePlotZoomFactor "Micro Window" "GC1-LMC7" 32
+-SetPlotWaveformColor "Micro Window" "GC1-LMC7" 25 25 112
+
+-AddPlot "Micro Window" "GC1-LMC8"
+-SetPlotEnabled "Micro Window" "GC1-LMC8" True
+-SetTimePlotZoomFactor "Micro Window" "GC1-LMC8" 32
+-SetPlotWaveformColor "Micro Window" "GC1-LMC8" 25 25 112
+
+-AddPlot "Micro Window" "GC2-LOF1"
+-SetPlotEnabled "Micro Window" "GC2-LOF1" True
+-SetTimePlotZoomFactor "Micro Window" "GC2-LOF1" 32
+-SetPlotWaveformColor "Micro Window" "GC2-LOF1" 25 25 112
+
+-AddPlot "Micro Window" "GC2-LOF2"
+-SetPlotEnabled "Micro Window" "GC2-LOF2" True
+-SetTimePlotZoomFactor "Micro Window" "GC2-LOF2" 32
+-SetPlotWaveformColor "Micro Window" "GC2-LOF2" 25 25 112
+
+-AddPlot "Micro Window" "GC2-LOF3"
+-SetPlotEnabled "Micro Window" "GC2-LOF3" True
+-SetTimePlotZoomFactor "Micro Window" "GC2-LOF3" 32
+-SetPlotWaveformColor "Micro Window" "GC2-LOF3" 25 25 112
+
+-AddPlot "Micro Window" "GC2-LOF4"
+-SetPlotEnabled "Micro Window" "GC2-LOF4" True
+-SetTimePlotZoomFactor "Micro Window" "GC2-LOF4" 32
+-SetPlotWaveformColor "Micro Window" "GC2-LOF4" 25 25 112
+
+-AddPlot "Micro Window" "GC2-LOF5"
+-SetPlotEnabled "Micro Window" "GC2-LOF5" True
+-SetTimePlotZoomFactor "Micro Window" "GC2-LOF5" 32
+-SetPlotWaveformColor "Micro Window" "GC2-LOF5" 25 25 112
+
+-AddPlot "Micro Window" "GC2-LOF6"
+-SetPlotEnabled "Micro Window" "GC2-LOF6" True
+-SetTimePlotZoomFactor "Micro Window" "GC2-LOF6" 32
+-SetPlotWaveformColor "Micro Window" "GC2-LOF6" 25 25 112
+
+-AddPlot "Micro Window" "GC2-LOF7"
+-SetPlotEnabled "Micro Window" "GC2-LOF7" True
+-SetTimePlotZoomFactor "Micro Window" "GC2-LOF7" 32
+-SetPlotWaveformColor "Micro Window" "GC2-LOF7" 25 25 112
+
+-AddPlot "Micro Window" "GC2-LOF8"
+-SetPlotEnabled "Micro Window" "GC2-LOF8" True
+-SetTimePlotZoomFactor "Micro Window" "GC2-LOF8" 32
+-SetPlotWaveformColor "Micro Window" "GC2-LOF8" 25 25 112
+
+# Plot Window Setup for "Alternate Reference Micro Window"
+-CreatePlotWindow Time "Alternate Reference Micro Window"
+-SetPlotWindowSpreadType "Alternate Reference Micro Window" Spread
+-SetPlotWindowPlotType "Alternate Reference Micro Window" Sweep
+-SetPlotWindowTimeframe "Alternate Reference Micro Window" 5000
+-SetPlotWindowHistoryTimeframe "Alternate Reference Micro Window" 30
+-SetPlotWindowShowGridLines "Alternate Reference Micro Window" True
+-SetPlotWindowBackgroundColor "Alternate Reference Micro Window" 230 217 255
+-SetPlotWindowPosition "Alternate Reference Micro Window" 14 807 1449 746
+-SetPlotWindowOverlay "Alternate Reference Micro Window" False
+-SetPlotWindowShowTitleBar "Alternate Reference Micro Window" True
+# Plot addition and setup for "Alternate Reference Micro Window"
+
+# Plot Window Setup for "Macro Window"
+-CreatePlotWindow Time "Macro Window"
+-SetPlotWindowSpreadType "Macro Window" Spread
+-SetPlotWindowPlotType "Macro Window" Sweep
+-SetPlotWindowTimeframe "Macro Window" 5000
+-SetPlotWindowHistoryTimeframe "Macro Window" 30
+-SetPlotWindowShowGridLines "Macro Window" True
+-SetPlotWindowBackgroundColor "Macro Window" 232 242 237
+-SetPlotWindowPosition "Macro Window" 14 807 1449 746
+-SetPlotWindowOverlay "Macro Window" False
+-SetPlotWindowShowTitleBar "Macro Window" True
+# Plot addition and setup for "Macro Window"
+
+-AddPlot "Macro Window" "LA1"
+-SetPlotEnabled "Macro Window" "LA1" True
+-SetTimePlotZoomFactor "Macro Window" "LA1" 32
+-SetPlotWaveformColor "Macro Window" "LA1" 25 25 112
+
+-AddPlot "Macro Window" "LA2"
+-SetPlotEnabled "Macro Window" "LA2" True
+-SetTimePlotZoomFactor "Macro Window" "LA2" 32
+-SetPlotWaveformColor "Macro Window" "LA2" 25 25 112
+
+-AddPlot "Macro Window" "LA3"
+-SetPlotEnabled "Macro Window" "LA3" True
+-SetTimePlotZoomFactor "Macro Window" "LA3" 32
+-SetPlotWaveformColor "Macro Window" "LA3" 25 25 112
+
+-AddPlot "Macro Window" "LA4"
+-SetPlotEnabled "Macro Window" "LA4" True
+-SetTimePlotZoomFactor "Macro Window" "LA4" 32
+-SetPlotWaveformColor "Macro Window" "LA4" 25 25 112
+
+-AddPlot "Macro Window" "LA5"
+-SetPlotEnabled "Macro Window" "LA5" True
+-SetTimePlotZoomFactor "Macro Window" "LA5" 32
+-SetPlotWaveformColor "Macro Window" "LA5" 25 25 112
+
+-AddPlot "Macro Window" "LA6"
+-SetPlotEnabled "Macro Window" "LA6" True
+-SetTimePlotZoomFactor "Macro Window" "LA6" 32
+-SetPlotWaveformColor "Macro Window" "LA6" 25 25 112
+
+-AddPlot "Macro Window" "LA7"
+-SetPlotEnabled "Macro Window" "LA7" True
+-SetTimePlotZoomFactor "Macro Window" "LA7" 32
+-SetPlotWaveformColor "Macro Window" "LA7" 25 25 112
+
+-AddPlot "Macro Window" "RA1"
+-SetPlotEnabled "Macro Window" "RA1" True
+-SetTimePlotZoomFactor "Macro Window" "RA1" 32
+-SetPlotWaveformColor "Macro Window" "RA1" 25 25 112
+
+-AddPlot "Macro Window" "RA2"
+-SetPlotEnabled "Macro Window" "RA2" True
+-SetTimePlotZoomFactor "Macro Window" "RA2" 32
+-SetPlotWaveformColor "Macro Window" "RA2" 25 25 112
+
+-AddPlot "Macro Window" "RA3"
+-SetPlotEnabled "Macro Window" "RA3" True
+-SetTimePlotZoomFactor "Macro Window" "RA3" 32
+-SetPlotWaveformColor "Macro Window" "RA3" 25 25 112
+
+-AddPlot "Macro Window" "RA4"
+-SetPlotEnabled "Macro Window" "RA4" True
+-SetTimePlotZoomFactor "Macro Window" "RA4" 32
+-SetPlotWaveformColor "Macro Window" "RA4" 25 25 112
+
+-AddPlot "Macro Window" "RA5"
+-SetPlotEnabled "Macro Window" "RA5" True
+-SetTimePlotZoomFactor "Macro Window" "RA5" 32
+-SetPlotWaveformColor "Macro Window" "RA5" 25 25 112
+
+-AddPlot "Macro Window" "RA6"
+-SetPlotEnabled "Macro Window" "RA6" True
+-SetTimePlotZoomFactor "Macro Window" "RA6" 32
+-SetPlotWaveformColor "Macro Window" "RA6" 25 25 112
+
+-AddPlot "Macro Window" "RA7"
+-SetPlotEnabled "Macro Window" "RA7" True
+-SetTimePlotZoomFactor "Macro Window" "RA7" 32
+-SetPlotWaveformColor "Macro Window" "RA7" 25 25 112
+
+-AddPlot "Macro Window" "RA8"
+-SetPlotEnabled "Macro Window" "RA8" True
+-SetTimePlotZoomFactor "Macro Window" "RA8" 32
+-SetPlotWaveformColor "Macro Window" "RA8" 25 25 112
+
+-AddPlot "Macro Window" "LOF1"
+-SetPlotEnabled "Macro Window" "LOF1" True
+-SetTimePlotZoomFactor "Macro Window" "LOF1" 32
+-SetPlotWaveformColor "Macro Window" "LOF1" 25 25 112
+
+-AddPlot "Macro Window" "LOF2"
+-SetPlotEnabled "Macro Window" "LOF2" True
+-SetTimePlotZoomFactor "Macro Window" "LOF2" 32
+-SetPlotWaveformColor "Macro Window" "LOF2" 25 25 112
+
+-AddPlot "Macro Window" "LOF3"
+-SetPlotEnabled "Macro Window" "LOF3" True
+-SetTimePlotZoomFactor "Macro Window" "LOF3" 32
+-SetPlotWaveformColor "Macro Window" "LOF3" 25 25 112
+
+-AddPlot "Macro Window" "LOF4"
+-SetPlotEnabled "Macro Window" "LOF4" True
+-SetTimePlotZoomFactor "Macro Window" "LOF4" 32
+-SetPlotWaveformColor "Macro Window" "LOF4" 25 25 112
+
+-AddPlot "Macro Window" "LOF5"
+-SetPlotEnabled "Macro Window" "LOF5" True
+-SetTimePlotZoomFactor "Macro Window" "LOF5" 32
+-SetPlotWaveformColor "Macro Window" "LOF5" 25 25 112
+
+-AddPlot "Macro Window" "LOF6"
+-SetPlotEnabled "Macro Window" "LOF6" True
+-SetTimePlotZoomFactor "Macro Window" "LOF6" 32
+-SetPlotWaveformColor "Macro Window" "LOF6" 25 25 112
+
+-AddPlot "Macro Window" "LOF7"
+-SetPlotEnabled "Macro Window" "LOF7" True
+-SetTimePlotZoomFactor "Macro Window" "LOF7" 32
+-SetPlotWaveformColor "Macro Window" "LOF7" 25 25 112
+
+-AddPlot "Macro Window" "LOF8"
+-SetPlotEnabled "Macro Window" "LOF8" True
+-SetTimePlotZoomFactor "Macro Window" "LOF8" 32
+-SetPlotWaveformColor "Macro Window" "LOF8" 25 25 112
+
+-AddPlot "Macro Window" "ROF1"
+-SetPlotEnabled "Macro Window" "ROF1" True
+-SetTimePlotZoomFactor "Macro Window" "ROF1" 32
+-SetPlotWaveformColor "Macro Window" "ROF1" 25 25 112
+
+# Plot Window Setup for "Sleep Montage"
+-CreatePlotWindow Time "Sleep Montage"
+-SetPlotWindowSpreadType "Sleep Montage" Spread
+-SetPlotWindowPlotType "Sleep Montage" Sweep
+-SetPlotWindowTimeframe "Sleep Montage" 5000
+-SetPlotWindowHistoryTimeframe "Sleep Montage" 30
+-SetPlotWindowShowGridLines "Sleep Montage" True
+-SetPlotWindowPosition "Sleep Montage" 14 807 1449 746
+-SetPlotWindowOverlay "Sleep Montage" False
+-SetPlotWindowShowTitleBar "Sleep Montage" True
+# Plot addition and setup for "Sleep Montage"
+
+-AddPlot "Sleep Montage" "A1"
+-SetPlotEnabled "Sleep Montage" "A1" True
+
+-AddPlot "Sleep Montage" "A2"
+-SetPlotEnabled "Sleep Montage" "A2" True
+
+# Plot Window Setup for "Additional Plots"
+-CreatePlotWindow Time "Additional Plots"
+-SetPlotWindowSpreadType "Additional Plots" Spread
+-SetPlotWindowPlotType "Additional Plots" Sweep
+-SetPlotWindowTimeframe "Additional Plots" 5000
+-SetPlotWindowHistoryTimeframe "Additional Plots" 30
+-SetPlotWindowShowGridLines "Additional Plots" True
+-SetPlotWindowPosition "Additional Plots" 14 807 1449 746
+-SetPlotWindowOverlay "Additional Plots" False
+-SetPlotWindowShowTitleBar "Additional Plots" True
+# Plot addition and setup for "Additional Plots"
+
+-AddPlot "Additional Plots" "TTLSync"
+-SetPlotEnabled "Additional Plots" "TTLSync" True
+
+-AddPlot "Additional Plots" "HR"
+-SetPlotEnabled "Additional Plots" "HR" True
+
+# Plot Window Setup for "Spike Window 1"
+-CreatePlotWindow Spike "Spike Window 1"
+-SetPlotWindowPlotType "Spike Window 1" WaveformFeature
+-SetPlotWindowShowIcons "Spike Window 1" True
+-SetPlotWindowShowTextValues "Spike Window 1" True
+-SetPlotWindowNumberFeaturePlotsMaximizedView "Spike Window 1" 1
+-SetPlotWindowNumberFeaturePlotsNormalView "Spike Window 1" 1
+-SetPlotWindowPosition "Spike Window 1" 1473 50 1083 393
+-SetPlotWindowOverlay "Spike Window 1" False
+-SetPlotWindowShowTitleBar "Spike Window 1" True
+
+# Plot addition and setup for "Spike Window 1"
+-AddPlot "Spike Window 1" "SEGA1-LA1"
+-SetPlotEnabled "Spike Window 1" "SEGA1-LA1" True
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA1" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA1-LA1" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA1-LA1" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA1-LA2"
+-SetPlotEnabled "Spike Window 1" "SEGA1-LA2" True
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA2" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA1-LA2" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA1-LA2" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA1-LA3"
+-SetPlotEnabled "Spike Window 1" "SEGA1-LA3" True
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA3" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA1-LA3" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA1-LA3" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA1-LA4"
+-SetPlotEnabled "Spike Window 1" "SEGA1-LA4" True
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA4" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA1-LA4" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA1-LA4" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA1-LA5"
+-SetPlotEnabled "Spike Window 1" "SEGA1-LA5" True
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA5" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA1-LA5" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA1-LA5" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA1-LA6"
+-SetPlotEnabled "Spike Window 1" "SEGA1-LA6" True
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA6" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA1-LA6" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA1-LA6" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA1-LA7"
+-SetPlotEnabled "Spike Window 1" "SEGA1-LA7" True
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA7" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA1-LA7" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA1-LA7" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA1-LA8"
+-SetPlotEnabled "Spike Window 1" "SEGA1-LA8" True
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA1-LA8" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA1-LA8" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA1-LA8" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA2-LAC1"
+-SetPlotEnabled "Spike Window 1" "SEGA2-LAC1" True
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC1" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA2-LAC1" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA2-LAC1" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA2-LAC2"
+-SetPlotEnabled "Spike Window 1" "SEGA2-LAC2" True
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC2" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA2-LAC2" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA2-LAC2" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA2-LAC3"
+-SetPlotEnabled "Spike Window 1" "SEGA2-LAC3" True
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC3" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA2-LAC3" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA2-LAC3" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA2-LAC4"
+-SetPlotEnabled "Spike Window 1" "SEGA2-LAC4" True
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC4" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA2-LAC4" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA2-LAC4" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA2-LAC5"
+-SetPlotEnabled "Spike Window 1" "SEGA2-LAC5" True
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC5" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA2-LAC5" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA2-LAC5" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA2-LAC6"
+-SetPlotEnabled "Spike Window 1" "SEGA2-LAC6" True
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC6" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA2-LAC6" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA2-LAC6" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA2-LAC7"
+-SetPlotEnabled "Spike Window 1" "SEGA2-LAC7" True
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC7" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA2-LAC7" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA2-LAC7" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA2-LAC8"
+-SetPlotEnabled "Spike Window 1" "SEGA2-LAC8" True
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA2-LAC8" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA2-LAC8" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA2-LAC8" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA3-LACd1"
+-SetPlotEnabled "Spike Window 1" "SEGA3-LACd1" True
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd1" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA3-LACd1" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA3-LACd1" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA3-LACd2"
+-SetPlotEnabled "Spike Window 1" "SEGA3-LACd2" True
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd2" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA3-LACd2" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA3-LACd2" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA3-LACd3"
+-SetPlotEnabled "Spike Window 1" "SEGA3-LACd3" True
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd3" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA3-LACd3" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA3-LACd3" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA3-LACd4"
+-SetPlotEnabled "Spike Window 1" "SEGA3-LACd4" True
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd4" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA3-LACd4" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA3-LACd4" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA3-LACd5"
+-SetPlotEnabled "Spike Window 1" "SEGA3-LACd5" True
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd5" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA3-LACd5" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA3-LACd5" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA3-LACd6"
+-SetPlotEnabled "Spike Window 1" "SEGA3-LACd6" True
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd6" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA3-LACd6" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA3-LACd6" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA3-LACd7"
+-SetPlotEnabled "Spike Window 1" "SEGA3-LACd7" True
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd7" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA3-LACd7" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA3-LACd7" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGA3-LACd8"
+-SetPlotEnabled "Spike Window 1" "SEGA3-LACd8" True
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGA3-LACd8" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGA3-LACd8" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGA3-LACd8" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB1-RA1"
+-SetPlotEnabled "Spike Window 1" "SEGB1-RA1" True
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA1" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB1-RA1" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB1-RA1" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB1-RA2"
+-SetPlotEnabled "Spike Window 1" "SEGB1-RA2" True
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA2" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB1-RA2" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB1-RA2" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB1-RA3"
+-SetPlotEnabled "Spike Window 1" "SEGB1-RA3" True
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA3" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB1-RA3" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB1-RA3" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB1-RA4"
+-SetPlotEnabled "Spike Window 1" "SEGB1-RA4" True
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA4" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB1-RA4" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB1-RA4" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB1-RA5"
+-SetPlotEnabled "Spike Window 1" "SEGB1-RA5" True
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA5" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB1-RA5" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB1-RA5" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB1-RA6"
+-SetPlotEnabled "Spike Window 1" "SEGB1-RA6" True
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA6" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB1-RA6" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB1-RA6" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB1-RA7"
+-SetPlotEnabled "Spike Window 1" "SEGB1-RA7" True
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA7" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB1-RA7" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB1-RA7" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB1-RA8"
+-SetPlotEnabled "Spike Window 1" "SEGB1-RA8" True
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB1-RA8" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB1-RA8" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB1-RA8" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB2-LAC1"
+-SetPlotEnabled "Spike Window 1" "SEGB2-LAC1" True
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC1" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB2-LAC1" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB2-LAC1" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB2-LAC2"
+-SetPlotEnabled "Spike Window 1" "SEGB2-LAC2" True
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC2" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB2-LAC2" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB2-LAC2" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB2-LAC3"
+-SetPlotEnabled "Spike Window 1" "SEGB2-LAC3" True
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC3" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB2-LAC3" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB2-LAC3" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB2-LAC4"
+-SetPlotEnabled "Spike Window 1" "SEGB2-LAC4" True
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC4" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB2-LAC4" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB2-LAC4" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB2-LAC5"
+-SetPlotEnabled "Spike Window 1" "SEGB2-LAC5" True
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC5" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB2-LAC5" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB2-LAC5" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB2-LAC6"
+-SetPlotEnabled "Spike Window 1" "SEGB2-LAC6" True
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC6" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB2-LAC6" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB2-LAC6" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB2-LAC7"
+-SetPlotEnabled "Spike Window 1" "SEGB2-LAC7" True
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC7" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB2-LAC7" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB2-LAC7" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGB2-LAC8"
+-SetPlotEnabled "Spike Window 1" "SEGB2-LAC8" True
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGB2-LAC8" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGB2-LAC8" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGB2-LAC8" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC1-LMC1"
+-SetPlotEnabled "Spike Window 1" "SEGC1-LMC1" True
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC1" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC1-LMC1" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC1-LMC1" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC1-LMC2"
+-SetPlotEnabled "Spike Window 1" "SEGC1-LMC2" True
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC2" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC1-LMC2" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC1-LMC2" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC1-LMC3"
+-SetPlotEnabled "Spike Window 1" "SEGC1-LMC3" True
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC3" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC1-LMC3" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC1-LMC3" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC1-LMC4"
+-SetPlotEnabled "Spike Window 1" "SEGC1-LMC4" True
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC4" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC1-LMC4" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC1-LMC4" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC1-LMC5"
+-SetPlotEnabled "Spike Window 1" "SEGC1-LMC5" True
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC5" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC1-LMC5" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC1-LMC5" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC1-LMC6"
+-SetPlotEnabled "Spike Window 1" "SEGC1-LMC6" True
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC6" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC1-LMC6" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC1-LMC6" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC1-LMC7"
+-SetPlotEnabled "Spike Window 1" "SEGC1-LMC7" True
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC7" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC1-LMC7" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC1-LMC7" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC1-LMC8"
+-SetPlotEnabled "Spike Window 1" "SEGC1-LMC8" True
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC1-LMC8" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC1-LMC8" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC1-LMC8" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC2-LOF1"
+-SetPlotEnabled "Spike Window 1" "SEGC2-LOF1" True
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF1" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC2-LOF1" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC2-LOF1" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC2-LOF2"
+-SetPlotEnabled "Spike Window 1" "SEGC2-LOF2" True
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF2" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC2-LOF2" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC2-LOF2" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC2-LOF3"
+-SetPlotEnabled "Spike Window 1" "SEGC2-LOF3" True
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF3" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC2-LOF3" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC2-LOF3" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC2-LOF4"
+-SetPlotEnabled "Spike Window 1" "SEGC2-LOF4" True
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF4" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC2-LOF4" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC2-LOF4" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC2-LOF5"
+-SetPlotEnabled "Spike Window 1" "SEGC2-LOF5" True
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF5" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC2-LOF5" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC2-LOF5" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC2-LOF6"
+-SetPlotEnabled "Spike Window 1" "SEGC2-LOF6" True
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF6" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC2-LOF6" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC2-LOF6" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC2-LOF7"
+-SetPlotEnabled "Spike Window 1" "SEGC2-LOF7" True
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF7" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC2-LOF7" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC2-LOF7" 0 -32767 32767 32767 -32767
+
+-AddPlot "Spike Window 1" "SEGC2-LOF8"
+-SetPlotEnabled "Spike Window 1" "SEGC2-LOF8" True
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 0 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 1 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 2 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 3 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 4 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 5 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 6 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 7 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 8 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 9 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 10 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 11 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 12 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 13 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 14 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 15 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 16 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 17 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 18 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 19 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 20 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 21 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 22 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 23 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 24 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 25 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 26 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 27 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 28 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 29 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 30 On
+-SetClusterDisplay "Spike Window 1" "SEGC2-LOF8" 31 On
+-SetFeaturePlotSources "Spike Window 1" "SEGC2-LOF8" 0 0 1
+-SetFeaturePlotView "Spike Window 1" "SEGC2-LOF8" 0 -32767 32767 32767 -32767
+
+#Audio Output Dialog Setup
+-SetDialogPosition Audio 0 42
+-SetDialogVisible Audio False
+
+#TTL Response Dialog Setup
+-SetDialogPosition TTLResponse 0 42
+-SetDialogVisible TTLResponse False
+
+#Audio Device Setup for Primary Sound Driver
+-SetAudioSource "Primary Sound Driver" Left None
+-SetAudioVolume "Primary Sound Driver" Left 100
+-SetAudioMute "Primary Sound Driver" Left Off
+-SetAudioSource "Primary Sound Driver" Right None
+-SetAudioVolume "Primary Sound Driver" Right 100
+-SetAudioMute "Primary Sound Driver" Right Off
+
+#Audio Device Setup for AcqSystem1_Audio0
+-SetAudioSource "AcqSystem1_Audio0" Left None
+-SetAudioVolume "AcqSystem1_Audio0" Left 100
+-SetAudioMute "AcqSystem1_Audio0" Left Off
+-SetAudioSource "AcqSystem1_Audio0" Right None
+-SetAudioVolume "AcqSystem1_Audio0" Right 100
+-SetAudioMute "AcqSystem1_Audio0" Right Off
+
+#Audio Device Setup for AcqSystem1_Audio1
+-SetAudioSource "AcqSystem1_Audio1" Left None
+-SetAudioVolume "AcqSystem1_Audio1" Left 100
+-SetAudioMute "AcqSystem1_Audio1" Left Off
+-SetAudioSource "AcqSystem1_Audio1" Right None
+-SetAudioVolume "AcqSystem1_Audio1" Right 100
+-SetAudioMute "AcqSystem1_Audio1" Right Off
+#Digital IO Device Creation and Setup for: AcqSystem1_0
+-SetDigitalIOPortDirection "AcqSystem1_0" 0 Input
+-SetDigitalIOUseStrobeBit "AcqSystem1_0" 0 False
+-SetDigitalIOEventsEnabled "AcqSystem1_0" 0 True
+-SetDigitalIOPulseDuration "AcqSystem1_0" 0 15
+-SetDigitalIOPortDirection "AcqSystem1_0" 1 Input
+-SetDigitalIOUseStrobeBit "AcqSystem1_0" 1 False
+-SetDigitalIOEventsEnabled "AcqSystem1_0" 1 True
+-SetDigitalIOPulseDuration "AcqSystem1_0" 1 15
+-SetDigitalIOPortDirection "AcqSystem1_0" 2 Input
+-SetDigitalIOUseStrobeBit "AcqSystem1_0" 2 False
+-SetDigitalIOEventsEnabled "AcqSystem1_0" 2 True
+-SetDigitalIOPulseDuration "AcqSystem1_0" 2 15
+-SetDigitalIOPortDirection "AcqSystem1_0" 3 Input
+-SetDigitalIOUseStrobeBit "AcqSystem1_0" 3 False
+-SetDigitalIOEventsEnabled "AcqSystem1_0" 3 True
+-SetDigitalIOPulseDuration "AcqSystem1_0" 3 15
+-SetDigitalIOInputScanDelay "AcqSystem1_0" 1
+
+#Subject Dialog Setup
+-SetDialogPosition Subject 133 175
+-SetDialogVisible Subject False
+

--- a/test/montage_config/config_Patient-999_exp-1_2025-02-10_19-26-39_MacrosOnly.cfg
+++ b/test/montage_config/config_Patient-999_exp-1_2025-02-10_19-26-39_MacrosOnly.cfg
@@ -1,0 +1,644 @@
+#Pegasus system setup file
+#Generated using Emily's Generator
+#File Generation Date:(yyyy/mm/dd hh:mm:ss) 2025/02/10 19:26:39
+
+#System Options Setup
+-SetSystemIdentifier "CNLNEURALYNX"
+
+#Acquisition Control Setup
+-SetDataDirectory "E:\ATLASData\D999\"
+-SetCreateNewFilesPerRecording True
+-SetMaxFileLength 2
+
+#Hardware Subsystem Creation and Setup for:  AcqSystem1
+-CreateHardwareSubSystem "AcqSystem1" ATLAS "32000" "192.168.3.10" "26011" "192.168.3.100" "26090"
+-SetDialogPosition "Hardware" 0 42
+-SetDialogVisible "Hardware" False
+
+#Reference Manager Setup
+#Video Capture Setup
+
+#Acquisition Entity creation and setup for: Events
+-SetNetComDataBufferingEnabled Events False
+-SetNetComDataBufferSize Events 3000
+
+#Acquisition Entity creation and setup for: "LA1"
+-CreateCscAcqEnt "LA1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA1" True
+-SetChannelNumber "LA1" 0
+-SetAcqEntReference "LA1" 32000000
+-SetInputRange "LA1" 3000
+-SetSubSamplingInterleave "LA1" 16
+-SetDspLowCutFilterEnabled "LA1" True
+-SetDspLowCutFrequency "LA1" 0.1
+-SetDspLowCutNumberTaps "LA1" 0
+-SetDspHighCutFilterEnabled "LA1" True
+-SetDspHighCutFrequency "LA1" 500
+-SetDspHighCutNumberTaps "LA1" 256
+-SetInputInverted "LA1" True
+-SetNetComDataBufferingEnabled "LA1" False
+-SetNetComDataBufferSize "LA1" 3000
+
+#Acquisition Entity creation and setup for: "LA2"
+-CreateCscAcqEnt "LA2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA2" True
+-SetChannelNumber "LA2" 1
+-SetAcqEntReference "LA2" 32000000
+-SetInputRange "LA2" 3000
+-SetSubSamplingInterleave "LA2" 16
+-SetDspLowCutFilterEnabled "LA2" True
+-SetDspLowCutFrequency "LA2" 0.1
+-SetDspLowCutNumberTaps "LA2" 0
+-SetDspHighCutFilterEnabled "LA2" True
+-SetDspHighCutFrequency "LA2" 500
+-SetDspHighCutNumberTaps "LA2" 256
+-SetInputInverted "LA2" True
+-SetNetComDataBufferingEnabled "LA2" False
+-SetNetComDataBufferSize "LA2" 3000
+
+#Acquisition Entity creation and setup for: "LA3"
+-CreateCscAcqEnt "LA3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA3" True
+-SetChannelNumber "LA3" 2
+-SetAcqEntReference "LA3" 32000000
+-SetInputRange "LA3" 3000
+-SetSubSamplingInterleave "LA3" 16
+-SetDspLowCutFilterEnabled "LA3" True
+-SetDspLowCutFrequency "LA3" 0.1
+-SetDspLowCutNumberTaps "LA3" 0
+-SetDspHighCutFilterEnabled "LA3" True
+-SetDspHighCutFrequency "LA3" 500
+-SetDspHighCutNumberTaps "LA3" 256
+-SetInputInverted "LA3" True
+-SetNetComDataBufferingEnabled "LA3" False
+-SetNetComDataBufferSize "LA3" 3000
+
+#Acquisition Entity creation and setup for: "LA4"
+-CreateCscAcqEnt "LA4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA4" True
+-SetChannelNumber "LA4" 3
+-SetAcqEntReference "LA4" 32000000
+-SetInputRange "LA4" 3000
+-SetSubSamplingInterleave "LA4" 16
+-SetDspLowCutFilterEnabled "LA4" True
+-SetDspLowCutFrequency "LA4" 0.1
+-SetDspLowCutNumberTaps "LA4" 0
+-SetDspHighCutFilterEnabled "LA4" True
+-SetDspHighCutFrequency "LA4" 500
+-SetDspHighCutNumberTaps "LA4" 256
+-SetInputInverted "LA4" True
+-SetNetComDataBufferingEnabled "LA4" False
+-SetNetComDataBufferSize "LA4" 3000
+
+#Acquisition Entity creation and setup for: "LA5"
+-CreateCscAcqEnt "LA5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA5" True
+-SetChannelNumber "LA5" 4
+-SetAcqEntReference "LA5" 32000000
+-SetInputRange "LA5" 3000
+-SetSubSamplingInterleave "LA5" 16
+-SetDspLowCutFilterEnabled "LA5" True
+-SetDspLowCutFrequency "LA5" 0.1
+-SetDspLowCutNumberTaps "LA5" 0
+-SetDspHighCutFilterEnabled "LA5" True
+-SetDspHighCutFrequency "LA5" 500
+-SetDspHighCutNumberTaps "LA5" 256
+-SetInputInverted "LA5" True
+-SetNetComDataBufferingEnabled "LA5" False
+-SetNetComDataBufferSize "LA5" 3000
+
+#Acquisition Entity creation and setup for: "LA6"
+-CreateCscAcqEnt "LA6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA6" True
+-SetChannelNumber "LA6" 5
+-SetAcqEntReference "LA6" 32000000
+-SetInputRange "LA6" 3000
+-SetSubSamplingInterleave "LA6" 16
+-SetDspLowCutFilterEnabled "LA6" True
+-SetDspLowCutFrequency "LA6" 0.1
+-SetDspLowCutNumberTaps "LA6" 0
+-SetDspHighCutFilterEnabled "LA6" True
+-SetDspHighCutFrequency "LA6" 500
+-SetDspHighCutNumberTaps "LA6" 256
+-SetInputInverted "LA6" True
+-SetNetComDataBufferingEnabled "LA6" False
+-SetNetComDataBufferSize "LA6" 3000
+
+#Acquisition Entity creation and setup for: "LA7"
+-CreateCscAcqEnt "LA7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LA7" True
+-SetChannelNumber "LA7" 6
+-SetAcqEntReference "LA7" 32000000
+-SetInputRange "LA7" 3000
+-SetSubSamplingInterleave "LA7" 16
+-SetDspLowCutFilterEnabled "LA7" True
+-SetDspLowCutFrequency "LA7" 0.1
+-SetDspLowCutNumberTaps "LA7" 0
+-SetDspHighCutFilterEnabled "LA7" True
+-SetDspHighCutFrequency "LA7" 500
+-SetDspHighCutNumberTaps "LA7" 256
+-SetInputInverted "LA7" True
+-SetNetComDataBufferingEnabled "LA7" False
+-SetNetComDataBufferSize "LA7" 3000
+
+#Acquisition Entity creation and setup for: "RA1"
+-CreateCscAcqEnt "RA1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA1" True
+-SetChannelNumber "RA1" 7
+-SetAcqEntReference "RA1" 32000000
+-SetInputRange "RA1" 3000
+-SetSubSamplingInterleave "RA1" 16
+-SetDspLowCutFilterEnabled "RA1" True
+-SetDspLowCutFrequency "RA1" 0.1
+-SetDspLowCutNumberTaps "RA1" 0
+-SetDspHighCutFilterEnabled "RA1" True
+-SetDspHighCutFrequency "RA1" 500
+-SetDspHighCutNumberTaps "RA1" 256
+-SetInputInverted "RA1" True
+-SetNetComDataBufferingEnabled "RA1" False
+-SetNetComDataBufferSize "RA1" 3000
+
+#Acquisition Entity creation and setup for: "RA2"
+-CreateCscAcqEnt "RA2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA2" True
+-SetChannelNumber "RA2" 8
+-SetAcqEntReference "RA2" 32000000
+-SetInputRange "RA2" 3000
+-SetSubSamplingInterleave "RA2" 16
+-SetDspLowCutFilterEnabled "RA2" True
+-SetDspLowCutFrequency "RA2" 0.1
+-SetDspLowCutNumberTaps "RA2" 0
+-SetDspHighCutFilterEnabled "RA2" True
+-SetDspHighCutFrequency "RA2" 500
+-SetDspHighCutNumberTaps "RA2" 256
+-SetInputInverted "RA2" True
+-SetNetComDataBufferingEnabled "RA2" False
+-SetNetComDataBufferSize "RA2" 3000
+
+#Acquisition Entity creation and setup for: "RA3"
+-CreateCscAcqEnt "RA3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA3" True
+-SetChannelNumber "RA3" 9
+-SetAcqEntReference "RA3" 32000000
+-SetInputRange "RA3" 3000
+-SetSubSamplingInterleave "RA3" 16
+-SetDspLowCutFilterEnabled "RA3" True
+-SetDspLowCutFrequency "RA3" 0.1
+-SetDspLowCutNumberTaps "RA3" 0
+-SetDspHighCutFilterEnabled "RA3" True
+-SetDspHighCutFrequency "RA3" 500
+-SetDspHighCutNumberTaps "RA3" 256
+-SetInputInverted "RA3" True
+-SetNetComDataBufferingEnabled "RA3" False
+-SetNetComDataBufferSize "RA3" 3000
+
+#Acquisition Entity creation and setup for: "RA4"
+-CreateCscAcqEnt "RA4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA4" True
+-SetChannelNumber "RA4" 10
+-SetAcqEntReference "RA4" 32000000
+-SetInputRange "RA4" 3000
+-SetSubSamplingInterleave "RA4" 16
+-SetDspLowCutFilterEnabled "RA4" True
+-SetDspLowCutFrequency "RA4" 0.1
+-SetDspLowCutNumberTaps "RA4" 0
+-SetDspHighCutFilterEnabled "RA4" True
+-SetDspHighCutFrequency "RA4" 500
+-SetDspHighCutNumberTaps "RA4" 256
+-SetInputInverted "RA4" True
+-SetNetComDataBufferingEnabled "RA4" False
+-SetNetComDataBufferSize "RA4" 3000
+
+#Acquisition Entity creation and setup for: "RA5"
+-CreateCscAcqEnt "RA5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA5" True
+-SetChannelNumber "RA5" 11
+-SetAcqEntReference "RA5" 32000000
+-SetInputRange "RA5" 3000
+-SetSubSamplingInterleave "RA5" 16
+-SetDspLowCutFilterEnabled "RA5" True
+-SetDspLowCutFrequency "RA5" 0.1
+-SetDspLowCutNumberTaps "RA5" 0
+-SetDspHighCutFilterEnabled "RA5" True
+-SetDspHighCutFrequency "RA5" 500
+-SetDspHighCutNumberTaps "RA5" 256
+-SetInputInverted "RA5" True
+-SetNetComDataBufferingEnabled "RA5" False
+-SetNetComDataBufferSize "RA5" 3000
+
+#Acquisition Entity creation and setup for: "RA6"
+-CreateCscAcqEnt "RA6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA6" True
+-SetChannelNumber "RA6" 12
+-SetAcqEntReference "RA6" 32000000
+-SetInputRange "RA6" 3000
+-SetSubSamplingInterleave "RA6" 16
+-SetDspLowCutFilterEnabled "RA6" True
+-SetDspLowCutFrequency "RA6" 0.1
+-SetDspLowCutNumberTaps "RA6" 0
+-SetDspHighCutFilterEnabled "RA6" True
+-SetDspHighCutFrequency "RA6" 500
+-SetDspHighCutNumberTaps "RA6" 256
+-SetInputInverted "RA6" True
+-SetNetComDataBufferingEnabled "RA6" False
+-SetNetComDataBufferSize "RA6" 3000
+
+#Acquisition Entity creation and setup for: "RA7"
+-CreateCscAcqEnt "RA7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA7" True
+-SetChannelNumber "RA7" 13
+-SetAcqEntReference "RA7" 32000000
+-SetInputRange "RA7" 3000
+-SetSubSamplingInterleave "RA7" 16
+-SetDspLowCutFilterEnabled "RA7" True
+-SetDspLowCutFrequency "RA7" 0.1
+-SetDspLowCutNumberTaps "RA7" 0
+-SetDspHighCutFilterEnabled "RA7" True
+-SetDspHighCutFrequency "RA7" 500
+-SetDspHighCutNumberTaps "RA7" 256
+-SetInputInverted "RA7" True
+-SetNetComDataBufferingEnabled "RA7" False
+-SetNetComDataBufferSize "RA7" 3000
+
+#Acquisition Entity creation and setup for: "RA8"
+-CreateCscAcqEnt "RA8" "AcqSystem1"
+-SetAcqEntProcessingEnabled "RA8" True
+-SetChannelNumber "RA8" 14
+-SetAcqEntReference "RA8" 32000000
+-SetInputRange "RA8" 3000
+-SetSubSamplingInterleave "RA8" 16
+-SetDspLowCutFilterEnabled "RA8" True
+-SetDspLowCutFrequency "RA8" 0.1
+-SetDspLowCutNumberTaps "RA8" 0
+-SetDspHighCutFilterEnabled "RA8" True
+-SetDspHighCutFrequency "RA8" 500
+-SetDspHighCutNumberTaps "RA8" 256
+-SetInputInverted "RA8" True
+-SetNetComDataBufferingEnabled "RA8" False
+-SetNetComDataBufferSize "RA8" 3000
+
+#Acquisition Entity creation and setup for: "LOF1"
+-CreateCscAcqEnt "LOF1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF1" True
+-SetChannelNumber "LOF1" 15
+-SetAcqEntReference "LOF1" 32000000
+-SetInputRange "LOF1" 3000
+-SetSubSamplingInterleave "LOF1" 16
+-SetDspLowCutFilterEnabled "LOF1" True
+-SetDspLowCutFrequency "LOF1" 0.1
+-SetDspLowCutNumberTaps "LOF1" 0
+-SetDspHighCutFilterEnabled "LOF1" True
+-SetDspHighCutFrequency "LOF1" 500
+-SetDspHighCutNumberTaps "LOF1" 256
+-SetInputInverted "LOF1" True
+-SetNetComDataBufferingEnabled "LOF1" False
+-SetNetComDataBufferSize "LOF1" 3000
+
+#Acquisition Entity creation and setup for: "LOF2"
+-CreateCscAcqEnt "LOF2" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF2" True
+-SetChannelNumber "LOF2" 16
+-SetAcqEntReference "LOF2" 32000000
+-SetInputRange "LOF2" 3000
+-SetSubSamplingInterleave "LOF2" 16
+-SetDspLowCutFilterEnabled "LOF2" True
+-SetDspLowCutFrequency "LOF2" 0.1
+-SetDspLowCutNumberTaps "LOF2" 0
+-SetDspHighCutFilterEnabled "LOF2" True
+-SetDspHighCutFrequency "LOF2" 500
+-SetDspHighCutNumberTaps "LOF2" 256
+-SetInputInverted "LOF2" True
+-SetNetComDataBufferingEnabled "LOF2" False
+-SetNetComDataBufferSize "LOF2" 3000
+
+#Acquisition Entity creation and setup for: "LOF3"
+-CreateCscAcqEnt "LOF3" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF3" True
+-SetChannelNumber "LOF3" 17
+-SetAcqEntReference "LOF3" 32000000
+-SetInputRange "LOF3" 3000
+-SetSubSamplingInterleave "LOF3" 16
+-SetDspLowCutFilterEnabled "LOF3" True
+-SetDspLowCutFrequency "LOF3" 0.1
+-SetDspLowCutNumberTaps "LOF3" 0
+-SetDspHighCutFilterEnabled "LOF3" True
+-SetDspHighCutFrequency "LOF3" 500
+-SetDspHighCutNumberTaps "LOF3" 256
+-SetInputInverted "LOF3" True
+-SetNetComDataBufferingEnabled "LOF3" False
+-SetNetComDataBufferSize "LOF3" 3000
+
+#Acquisition Entity creation and setup for: "LOF4"
+-CreateCscAcqEnt "LOF4" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF4" True
+-SetChannelNumber "LOF4" 18
+-SetAcqEntReference "LOF4" 32000000
+-SetInputRange "LOF4" 3000
+-SetSubSamplingInterleave "LOF4" 16
+-SetDspLowCutFilterEnabled "LOF4" True
+-SetDspLowCutFrequency "LOF4" 0.1
+-SetDspLowCutNumberTaps "LOF4" 0
+-SetDspHighCutFilterEnabled "LOF4" True
+-SetDspHighCutFrequency "LOF4" 500
+-SetDspHighCutNumberTaps "LOF4" 256
+-SetInputInverted "LOF4" True
+-SetNetComDataBufferingEnabled "LOF4" False
+-SetNetComDataBufferSize "LOF4" 3000
+
+#Acquisition Entity creation and setup for: "LOF5"
+-CreateCscAcqEnt "LOF5" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF5" True
+-SetChannelNumber "LOF5" 19
+-SetAcqEntReference "LOF5" 32000000
+-SetInputRange "LOF5" 3000
+-SetSubSamplingInterleave "LOF5" 16
+-SetDspLowCutFilterEnabled "LOF5" True
+-SetDspLowCutFrequency "LOF5" 0.1
+-SetDspLowCutNumberTaps "LOF5" 0
+-SetDspHighCutFilterEnabled "LOF5" True
+-SetDspHighCutFrequency "LOF5" 500
+-SetDspHighCutNumberTaps "LOF5" 256
+-SetInputInverted "LOF5" True
+-SetNetComDataBufferingEnabled "LOF5" False
+-SetNetComDataBufferSize "LOF5" 3000
+
+#Acquisition Entity creation and setup for: "LOF6"
+-CreateCscAcqEnt "LOF6" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF6" True
+-SetChannelNumber "LOF6" 20
+-SetAcqEntReference "LOF6" 32000000
+-SetInputRange "LOF6" 3000
+-SetSubSamplingInterleave "LOF6" 16
+-SetDspLowCutFilterEnabled "LOF6" True
+-SetDspLowCutFrequency "LOF6" 0.1
+-SetDspLowCutNumberTaps "LOF6" 0
+-SetDspHighCutFilterEnabled "LOF6" True
+-SetDspHighCutFrequency "LOF6" 500
+-SetDspHighCutNumberTaps "LOF6" 256
+-SetInputInverted "LOF6" True
+-SetNetComDataBufferingEnabled "LOF6" False
+-SetNetComDataBufferSize "LOF6" 3000
+
+#Acquisition Entity creation and setup for: "LOF7"
+-CreateCscAcqEnt "LOF7" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF7" True
+-SetChannelNumber "LOF7" 21
+-SetAcqEntReference "LOF7" 32000000
+-SetInputRange "LOF7" 3000
+-SetSubSamplingInterleave "LOF7" 16
+-SetDspLowCutFilterEnabled "LOF7" True
+-SetDspLowCutFrequency "LOF7" 0.1
+-SetDspLowCutNumberTaps "LOF7" 0
+-SetDspHighCutFilterEnabled "LOF7" True
+-SetDspHighCutFrequency "LOF7" 500
+-SetDspHighCutNumberTaps "LOF7" 256
+-SetInputInverted "LOF7" True
+-SetNetComDataBufferingEnabled "LOF7" False
+-SetNetComDataBufferSize "LOF7" 3000
+
+#Acquisition Entity creation and setup for: "LOF8"
+-CreateCscAcqEnt "LOF8" "AcqSystem1"
+-SetAcqEntProcessingEnabled "LOF8" True
+-SetChannelNumber "LOF8" 22
+-SetAcqEntReference "LOF8" 32000000
+-SetInputRange "LOF8" 3000
+-SetSubSamplingInterleave "LOF8" 16
+-SetDspLowCutFilterEnabled "LOF8" True
+-SetDspLowCutFrequency "LOF8" 0.1
+-SetDspLowCutNumberTaps "LOF8" 0
+-SetDspHighCutFilterEnabled "LOF8" True
+-SetDspHighCutFrequency "LOF8" 500
+-SetDspHighCutNumberTaps "LOF8" 256
+-SetInputInverted "LOF8" True
+-SetNetComDataBufferingEnabled "LOF8" False
+-SetNetComDataBufferSize "LOF8" 3000
+
+#Acquisition Entity creation and setup for: "ROF1"
+-CreateCscAcqEnt "ROF1" "AcqSystem1"
+-SetAcqEntProcessingEnabled "ROF1" True
+-SetChannelNumber "ROF1" 23
+-SetAcqEntReference "ROF1" 32000000
+-SetInputRange "ROF1" 3000
+-SetSubSamplingInterleave "ROF1" 16
+-SetDspLowCutFilterEnabled "ROF1" True
+-SetDspLowCutFrequency "ROF1" 0.1
+-SetDspLowCutNumberTaps "ROF1" 0
+-SetDspHighCutFilterEnabled "ROF1" True
+-SetDspHighCutFrequency "ROF1" 500
+-SetDspHighCutNumberTaps "ROF1" 256
+-SetInputInverted "ROF1" True
+-SetNetComDataBufferingEnabled "ROF1" False
+-SetNetComDataBufferSize "ROF1" 3000
+
+#Main Window Setup
+-SetDialogPosition Main -16 0
+-SetDialogVisible Main True
+
+#System Status Dialog Setup
+-SetSystemStatusShowDetails True
+-SetDialogPosition Status 5 55
+-SetSystemStatusMessageFilter Fatal on
+-SetSystemStatusMessageFilter Error on
+-SetSystemStatusMessageFilter Warning on
+-SetSystemStatusMessageFilter Notice off
+-SetSystemStatusMessageFilter Data off
+-SetDialogVisible Status True
+
+#Properties Display Setup
+-SetDialogPosition Properties 1374 790
+-SetDialogVisible Properties True
+
+#Event Dialog Setup
+-SetDialogPosition Events 0 42
+-SetDialogVisible Events True
+-SetEventStringImmediateMode Off
+-SetEventStringSingleKeyMode Off
+-SetEventDisplayTTLValueFormat Binary
+
+# Plot Window Setup for "Macro Window"
+-CreatePlotWindow Time "Macro Window"
+-SetPlotWindowSpreadType "Macro Window" Spread
+-SetPlotWindowPlotType "Macro Window" Sweep
+-SetPlotWindowTimeframe "Macro Window" 5000
+-SetPlotWindowHistoryTimeframe "Macro Window" 30
+-SetPlotWindowShowGridLines "Macro Window" True
+-SetPlotWindowBackgroundColor "Macro Window" 232 242 237
+-SetPlotWindowPosition "Macro Window" 14 807 1449 746
+-SetPlotWindowOverlay "Macro Window" False
+-SetPlotWindowShowTitleBar "Macro Window" True
+# Plot addition and setup for "Macro Window"
+
+-AddPlot "Macro Window" "LA1"
+-SetPlotEnabled "Macro Window" "LA1" True
+-SetTimePlotZoomFactor "Macro Window" "LA1" 32
+-SetPlotWaveformColor "Macro Window" "LA1" 25 25 112
+
+-AddPlot "Macro Window" "LA2"
+-SetPlotEnabled "Macro Window" "LA2" True
+-SetTimePlotZoomFactor "Macro Window" "LA2" 32
+-SetPlotWaveformColor "Macro Window" "LA2" 25 25 112
+
+-AddPlot "Macro Window" "LA3"
+-SetPlotEnabled "Macro Window" "LA3" True
+-SetTimePlotZoomFactor "Macro Window" "LA3" 32
+-SetPlotWaveformColor "Macro Window" "LA3" 25 25 112
+
+-AddPlot "Macro Window" "LA4"
+-SetPlotEnabled "Macro Window" "LA4" True
+-SetTimePlotZoomFactor "Macro Window" "LA4" 32
+-SetPlotWaveformColor "Macro Window" "LA4" 25 25 112
+
+-AddPlot "Macro Window" "LA5"
+-SetPlotEnabled "Macro Window" "LA5" True
+-SetTimePlotZoomFactor "Macro Window" "LA5" 32
+-SetPlotWaveformColor "Macro Window" "LA5" 25 25 112
+
+-AddPlot "Macro Window" "LA6"
+-SetPlotEnabled "Macro Window" "LA6" True
+-SetTimePlotZoomFactor "Macro Window" "LA6" 32
+-SetPlotWaveformColor "Macro Window" "LA6" 25 25 112
+
+-AddPlot "Macro Window" "LA7"
+-SetPlotEnabled "Macro Window" "LA7" True
+-SetTimePlotZoomFactor "Macro Window" "LA7" 32
+-SetPlotWaveformColor "Macro Window" "LA7" 25 25 112
+
+-AddPlot "Macro Window" "RA1"
+-SetPlotEnabled "Macro Window" "RA1" True
+-SetTimePlotZoomFactor "Macro Window" "RA1" 32
+-SetPlotWaveformColor "Macro Window" "RA1" 25 25 112
+
+-AddPlot "Macro Window" "RA2"
+-SetPlotEnabled "Macro Window" "RA2" True
+-SetTimePlotZoomFactor "Macro Window" "RA2" 32
+-SetPlotWaveformColor "Macro Window" "RA2" 25 25 112
+
+-AddPlot "Macro Window" "RA3"
+-SetPlotEnabled "Macro Window" "RA3" True
+-SetTimePlotZoomFactor "Macro Window" "RA3" 32
+-SetPlotWaveformColor "Macro Window" "RA3" 25 25 112
+
+-AddPlot "Macro Window" "RA4"
+-SetPlotEnabled "Macro Window" "RA4" True
+-SetTimePlotZoomFactor "Macro Window" "RA4" 32
+-SetPlotWaveformColor "Macro Window" "RA4" 25 25 112
+
+-AddPlot "Macro Window" "RA5"
+-SetPlotEnabled "Macro Window" "RA5" True
+-SetTimePlotZoomFactor "Macro Window" "RA5" 32
+-SetPlotWaveformColor "Macro Window" "RA5" 25 25 112
+
+-AddPlot "Macro Window" "RA6"
+-SetPlotEnabled "Macro Window" "RA6" True
+-SetTimePlotZoomFactor "Macro Window" "RA6" 32
+-SetPlotWaveformColor "Macro Window" "RA6" 25 25 112
+
+-AddPlot "Macro Window" "RA7"
+-SetPlotEnabled "Macro Window" "RA7" True
+-SetTimePlotZoomFactor "Macro Window" "RA7" 32
+-SetPlotWaveformColor "Macro Window" "RA7" 25 25 112
+
+-AddPlot "Macro Window" "RA8"
+-SetPlotEnabled "Macro Window" "RA8" True
+-SetTimePlotZoomFactor "Macro Window" "RA8" 32
+-SetPlotWaveformColor "Macro Window" "RA8" 25 25 112
+
+-AddPlot "Macro Window" "LOF1"
+-SetPlotEnabled "Macro Window" "LOF1" True
+-SetTimePlotZoomFactor "Macro Window" "LOF1" 32
+-SetPlotWaveformColor "Macro Window" "LOF1" 25 25 112
+
+-AddPlot "Macro Window" "LOF2"
+-SetPlotEnabled "Macro Window" "LOF2" True
+-SetTimePlotZoomFactor "Macro Window" "LOF2" 32
+-SetPlotWaveformColor "Macro Window" "LOF2" 25 25 112
+
+-AddPlot "Macro Window" "LOF3"
+-SetPlotEnabled "Macro Window" "LOF3" True
+-SetTimePlotZoomFactor "Macro Window" "LOF3" 32
+-SetPlotWaveformColor "Macro Window" "LOF3" 25 25 112
+
+-AddPlot "Macro Window" "LOF4"
+-SetPlotEnabled "Macro Window" "LOF4" True
+-SetTimePlotZoomFactor "Macro Window" "LOF4" 32
+-SetPlotWaveformColor "Macro Window" "LOF4" 25 25 112
+
+-AddPlot "Macro Window" "LOF5"
+-SetPlotEnabled "Macro Window" "LOF5" True
+-SetTimePlotZoomFactor "Macro Window" "LOF5" 32
+-SetPlotWaveformColor "Macro Window" "LOF5" 25 25 112
+
+-AddPlot "Macro Window" "LOF6"
+-SetPlotEnabled "Macro Window" "LOF6" True
+-SetTimePlotZoomFactor "Macro Window" "LOF6" 32
+-SetPlotWaveformColor "Macro Window" "LOF6" 25 25 112
+
+-AddPlot "Macro Window" "LOF7"
+-SetPlotEnabled "Macro Window" "LOF7" True
+-SetTimePlotZoomFactor "Macro Window" "LOF7" 32
+-SetPlotWaveformColor "Macro Window" "LOF7" 25 25 112
+
+-AddPlot "Macro Window" "LOF8"
+-SetPlotEnabled "Macro Window" "LOF8" True
+-SetTimePlotZoomFactor "Macro Window" "LOF8" 32
+-SetPlotWaveformColor "Macro Window" "LOF8" 25 25 112
+
+-AddPlot "Macro Window" "ROF1"
+-SetPlotEnabled "Macro Window" "ROF1" True
+-SetTimePlotZoomFactor "Macro Window" "ROF1" 32
+-SetPlotWaveformColor "Macro Window" "ROF1" 25 25 112
+
+#Audio Output Dialog Setup
+-SetDialogPosition Audio 0 42
+-SetDialogVisible Audio False
+
+#TTL Response Dialog Setup
+-SetDialogPosition TTLResponse 0 42
+-SetDialogVisible TTLResponse False
+
+#Audio Device Setup for Primary Sound Driver
+-SetAudioSource "Primary Sound Driver" Left None
+-SetAudioVolume "Primary Sound Driver" Left 100
+-SetAudioMute "Primary Sound Driver" Left Off
+-SetAudioSource "Primary Sound Driver" Right None
+-SetAudioVolume "Primary Sound Driver" Right 100
+-SetAudioMute "Primary Sound Driver" Right Off
+
+#Audio Device Setup for AcqSystem1_Audio0
+-SetAudioSource "AcqSystem1_Audio0" Left None
+-SetAudioVolume "AcqSystem1_Audio0" Left 100
+-SetAudioMute "AcqSystem1_Audio0" Left Off
+-SetAudioSource "AcqSystem1_Audio0" Right None
+-SetAudioVolume "AcqSystem1_Audio0" Right 100
+-SetAudioMute "AcqSystem1_Audio0" Right Off
+
+#Audio Device Setup for AcqSystem1_Audio1
+-SetAudioSource "AcqSystem1_Audio1" Left None
+-SetAudioVolume "AcqSystem1_Audio1" Left 100
+-SetAudioMute "AcqSystem1_Audio1" Left Off
+-SetAudioSource "AcqSystem1_Audio1" Right None
+-SetAudioVolume "AcqSystem1_Audio1" Right 100
+-SetAudioMute "AcqSystem1_Audio1" Right Off
+#Digital IO Device Creation and Setup for: AcqSystem1_0
+-SetDigitalIOPortDirection "AcqSystem1_0" 0 Input
+-SetDigitalIOUseStrobeBit "AcqSystem1_0" 0 False
+-SetDigitalIOEventsEnabled "AcqSystem1_0" 0 True
+-SetDigitalIOPulseDuration "AcqSystem1_0" 0 15
+-SetDigitalIOPortDirection "AcqSystem1_0" 1 Input
+-SetDigitalIOUseStrobeBit "AcqSystem1_0" 1 False
+-SetDigitalIOEventsEnabled "AcqSystem1_0" 1 True
+-SetDigitalIOPulseDuration "AcqSystem1_0" 1 15
+-SetDigitalIOPortDirection "AcqSystem1_0" 2 Input
+-SetDigitalIOUseStrobeBit "AcqSystem1_0" 2 False
+-SetDigitalIOEventsEnabled "AcqSystem1_0" 2 True
+-SetDigitalIOPulseDuration "AcqSystem1_0" 2 15
+-SetDigitalIOPortDirection "AcqSystem1_0" 3 Input
+-SetDigitalIOUseStrobeBit "AcqSystem1_0" 3 False
+-SetDigitalIOEventsEnabled "AcqSystem1_0" 3 True
+-SetDigitalIOPulseDuration "AcqSystem1_0" 3 15
+-SetDigitalIOInputScanDelay "AcqSystem1_0" 1
+
+#Subject Dialog Setup
+-SetDialogPosition Subject 133 175
+-SetDialogVisible Subject False
+

--- a/test/montage_config/montage_Patient-999_exp-1_2025-02-10_19-26-39.json
+++ b/test/montage_config/montage_Patient-999_exp-1_2025-02-10_19-26-39.json
@@ -1,0 +1,101 @@
+{
+  "PatientID": "999",
+  "ExperimentID": "1",
+  "Headstages": {
+    "GA": {
+      "Port1": {
+        "Micros": 8,
+        "BrainLabel": "LA"
+      },
+      "Port2": {
+        "Micros": 8,
+        "BrainLabel": "LAC"
+      },
+      "Port3": {
+        "Micros": 8,
+        "BrainLabel": "LACd"
+      },
+      "Port4": {
+        "Micros": 0,
+        "BrainLabel": "LA"
+      }
+    },
+    "GB": {
+      "Port1": {
+        "Micros": 8,
+        "BrainLabel": "RA"
+      },
+      "Port2": {
+        "Micros": 8,
+        "BrainLabel": "LAC"
+      },
+      "Port3": {
+        "Micros": 0,
+        "BrainLabel": "LA"
+      },
+      "Port4": {
+        "Micros": 0,
+        "BrainLabel": "LA"
+      }
+    },
+    "GC": {
+      "Port1": {
+        "Micros": 8,
+        "BrainLabel": "LMC"
+      },
+      "Port2": {
+        "Micros": 8,
+        "BrainLabel": "LOF"
+      },
+      "Port3": {
+        "Micros": 0,
+        "BrainLabel": "LA"
+      },
+      "Port4": {
+        "Micros": 0,
+        "BrainLabel": "LA"
+      }
+    },
+    "GD": {}
+  },
+  "macroChannels": [
+    [
+      "LA",
+      1,
+      7
+    ],
+    [
+      "RA",
+      8,
+      15
+    ],
+    [
+      "LOF",
+      16,
+      23
+    ],
+    [
+      "ROF",
+      24,
+      24
+    ]
+  ],
+  "miscChannels": [
+    [
+      "A1",
+      114
+    ],
+    [
+      "A2",
+      115
+    ],
+    [
+      "Analogue2",
+      117
+    ],
+    [
+      "Analogue3",
+      118
+    ]
+  ]
+}


### PR DESCRIPTION
[BUG] In the previous update, the skipped micro channels are not passed into the neuralynx config function `generatePegasusConfigFile`. As a result, later micro channels are set to the skipped port.

Also, remove the `MICROPHONE` and 'Analogue1` misc channels by default.

set the default input range of `Analogue2` to 800.

some minor updates in screening analysis.